### PR TITLE
fix(release): migrate Homebrew cask publish to GitHub App auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,12 +124,27 @@ jobs:
 
           echo "✅ Release v${VERSION} created successfully!"
 
-      - name: Update Homebrew cask
+      # Mint a 1-hour GitHub App installation token instead of using a
+      # static PAT. The `agiletec-inc-homebrew-publisher` App is installed
+      # on `homebrew-tap` only and shared via org-level credentials; same
+      # pattern as airis-workspace's release.yml. This eliminates the
+      # per-repo HOMEBREW_TAP_TOKEN PAT (which expires and breaks silently).
+      - name: Generate Homebrew tap App token
+        if: steps.check_tag.outputs.exists == 'false'
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.HOMEBREW_TAP_PUBLISHER_CLIENT_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_PUBLISHER_PRIVATE_KEY }}
+          owner: agiletec-inc
+          repositories: homebrew-tap
+
+      - name: Update Homebrew cask via PR
         if: steps.check_tag.outputs.exists == 'false'
         env:
-          HOMEBREW_TAP_TOKEN: ${{secrets.HOMEBREW_TAP_TOKEN}}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          set -e
+          set -euo pipefail
 
           VERSION=${{steps.version.outputs.version}}
           SHA256=${{steps.sha256.outputs.sha256}}
@@ -138,17 +153,19 @@ jobs:
           echo "   Version: $VERSION"
           echo "   SHA256: $SHA256"
 
-          # Clone homebrew-tap repository
-          git clone https://$HOMEBREW_TAP_TOKEN@github.com/agiletec-inc/homebrew-tap.git
+          # Clone homebrew-tap with the App's installation token
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/agiletec-inc/homebrew-tap.git"
           cd homebrew-tap
 
-          # Ensure we're on main branch
-          git checkout main || git checkout -b main
+          BRANCH="release/cmd-ime-v${VERSION}"
 
-          # Create Casks directory if it doesn't exist
+          # Rerun safety: drop any stale ref from a previous failed attempt
+          gh api -X DELETE "repos/agiletec-inc/homebrew-tap/git/refs/heads/${BRANCH}" 2>/dev/null || true
+
+          git checkout -b "$BRANCH"
+
           mkdir -p Casks
 
-          # Update cask
           cat > Casks/cmd-ime.rb <<EOF
           cask "cmd-ime" do
             version "${VERSION}"
@@ -179,11 +196,26 @@ jobs:
           end
           EOF
 
-          # Commit and push
-          git config user.name "GitHub Actions"
-          git config user.email "actions@github.com"
+          git config user.name "agiletec-inc-homebrew-publisher[bot]"
+          git config user.email "agiletec-inc-homebrew-publisher[bot]@users.noreply.github.com"
+
           git add Casks/cmd-ime.rb
-          git commit -m "Update cmd-ime to v${VERSION}" || echo "No changes to commit"
-          git push origin main || echo "Push failed, check if token has permissions"
+          if git diff --cached --quiet; then
+            echo "No changes to cask — skipping PR."
+            exit 0
+          fi
+          git commit -m "Update cmd-ime to v${VERSION}"
+          git push --set-upstream origin "$BRANCH"
+
+          # Open and immediately squash-merge. The App is a bypass actor on
+          # the `Homebrew tap protection` ruleset (bypass_mode: pull_request)
+          # so the merge succeeds even with required reviews.
+          PR_URL=$(gh pr create \
+            --base "$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)" \
+            --head "$BRANCH" \
+            --title "chore(cask): update cmd-ime to v${VERSION}" \
+            --body "Automated cask update from \`agiletec-inc/cmd-ime@v${VERSION}\`. The publisher App bypasses required-review enforcement; this PR merges immediately.")
+
+          gh pr merge --squash --delete-branch "$PR_URL"
 
           echo "✅ Homebrew cask updated to v${VERSION}"


### PR DESCRIPTION
## Why

cmd-ime/release.yml currently uses a static `HOMEBREW_TAP_TOKEN` PAT, embedded in the git clone URL:

```
git clone https://$HOMEBREW_TAP_TOKEN@github.com/agiletec-inc/homebrew-tap.git
```

PAT-based auth has the same well-known problems we just hit on airis-workspace v3.5.1:
- User-bound, so it dies when the issuing user's token expires or they leave the org
- Tied to one specific repo's secrets — every product that publishes to the tap needs its own copy

This PR migrates cmd-ime to the same shared App-based pattern that airis-workspace runs on now (validated end-to-end at v3.6.5: PR auto-merged, formula landed on tap main, `brew info agiletec-inc/tap/airis-workspace` confirms `stable 3.6.5`).

## What changes

The `Update Homebrew cask` step is replaced with an App-token + branch-PR pattern:

1. `actions/create-github-app-token@v3` mints a 1-hour token from the org-shared `agiletec-inc-homebrew-publisher` App, scoped to `homebrew-tap` only.
2. Clone tap with that token, create `release/cmd-ime-v${VERSION}` branch, write the cask, commit.
3. `gh pr create` then immediate `gh pr merge --squash --delete-branch`. The App is a bypass actor on the `Homebrew tap protection` ruleset (`bypass_mode: pull_request`, `required_reviews: 0`), so the merge goes through without human review while still leaving a PR audit trail.
4. Pre-push `gh api -X DELETE` on the branch ref, so reruns of failed jobs don't get stuck on stale refs (same fix as airis-workspace#196).

Auth and identity:
- `git config user.name "agiletec-inc-homebrew-publisher[bot]"` — commits attributed to the App's bot user, not "GitHub Actions".
- `gh` CLI uses `GH_TOKEN: ${{ steps.app-token.outputs.token }}` for both PR creation and merge.

## Org-level state (already provisioned)

- Variable `HOMEBREW_TAP_PUBLISHER_CLIENT_ID` — visibility includes `cmd-ime` ✓
- Secret `HOMEBREW_TAP_PUBLISHER_PRIVATE_KEY` — visibility includes `cmd-ime` ✓
- App `agiletec-inc-homebrew-publisher` — installed on `homebrew-tap`, has `contents: write` + `pull_requests: write` + `metadata: read`

## Cleanup after merge

```
gh secret delete HOMEBREW_TAP_TOKEN -R agiletec-inc/cmd-ime
```

That's the last legacy `HOMEBREW_TAP_TOKEN` PAT in the org — the four orphans (airis-mcp-gateway / airis-code / mindbase / neural) and airis-workspace's copy are already deleted.

## Test plan

- [ ] CI green
- [ ] After merge: cut a `cmd-ime` release tag (next version after 1.0.4 — whatever Cargo/info.plist says) and watch:
  - App token mint succeeds
  - PR appears on `agiletec-inc/homebrew-tap` from `app/agiletec-inc-homebrew-publisher`
  - PR auto-merges
  - `Casks/cmd-ime.rb` updated on tap main
  - `brew info agiletec-inc/tap/cmd-ime` shows new version