### PR TITLE
docs: fix README inconsistencies, add CHANGELOG and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: Bug report
+description: Report something that is broken in ⌘IME
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please fill in as much detail
+        as you can — the more we know, the faster we can fix it.
+
+  - type: input
+    id: version
+    attributes:
+      label: ⌘IME version
+      description: Click the menu bar ⌘ icon → "About ⌘IME …" — the version is in the title.
+      placeholder: e.g. 1.2.5
+    validations:
+      required: true
+
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      description: Apple menu  → About This Mac
+      placeholder: e.g. macOS 14.5 (Sonoma)
+    validations:
+      required: true
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: After granting Accessibility permission, the app does not start intercepting Command keys until I reinstall.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Install ⌘IME 1.2.5 from the latest .dmg
+        2. Launch and grant Accessibility permission
+        3. Press left Command — nothing happens
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: Left Command should switch the input source to alphanumeric.
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?
+      description: Console.app logs, screenshots, key mappings JSON (`defaults read com.kazuki.cmdime mappings`), etc.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and discussion
+    url: https://github.com/agiletec-inc/cmd-ime/discussions
+    about: For general questions, usage tips, and ideas not yet ready for an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,37 @@
+name: Feature request
+description: Suggest an idea for ⌘IME
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea? Tell us about it. ⌘IME aims to stay simple and focused —
+        the more concretely you describe the problem you want solved, the
+        easier it is to evaluate.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      placeholder: As a US-keyboard user with a Korean second IME, I want to bind ⇧+Right Command to a specific source.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: A short description of how you'd expect this to work.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      placeholder: Karabiner-Elements does this but feels overkill for one shortcut.
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to ⌘IME will be documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+Version bumps are derived from [Conventional Commits](https://www.conventionalcommits.org/)
+on the `main` branch via `.github/workflows/release.yml`.
+
+## [Unreleased]
+
+### Added
+- Issue templates (`bug_report.yml`, `feature_request.yml`) and a Discussions
+  link in the issue chooser.
+- This `CHANGELOG.md`.
+
+### Changed
+- Update check now queries the GitHub Releases API instead of the
+  decommissioned `ei-kana.appspot.com` endpoint.
+- README: align macOS minimum (13.0) with `Package.swift` and `Info.plist`,
+  fix Releases URL owner, drop references to a non-existent Xcode project,
+  describe Login Item / Updates UI in English.
+
+### Removed
+- `apps/cmd-ime-swift/scripts/build_app.sh` — host-specific dead script that
+  pulled a Storyboard from one developer's machine.
+
+## [1.2.5] - 2026-05-01
+
+### Changed
+- Switch Homebrew cask publish workflow to GitHub App authentication so
+  releases no longer depend on a personal access token that expires.
+
+## [1.2.0] - 2025-11-27
+
+### Added
+- Initial Swift Package Manager project under `apps/cmd-ime-swift/`.
+- `SMAppService.mainApp`-based "Launch at login" implementation
+  (`toggleLaunchAtStartup.swift`).
+- Code signing in `scripts/package.sh` (ad-hoc).
+
+### Changed
+- Renamed the app from `⌘英かな` to `⌘IME`.
+- Cleaned up repository structure.
+
+[Unreleased]: https://github.com/agiletec-inc/cmd-ime/compare/v1.2.5...HEAD
+[1.2.5]: https://github.com/agiletec-inc/cmd-ime/releases/tag/v1.2.5
+[1.2.0]: https://github.com/agiletec-inc/cmd-ime/releases/tag/v1.2.0

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Built with Swift for modern macOS.
 - **Simple & Fast**: Minimal resource usage, instant response
 - **Swift-Only Stack**: Native macOS code (no Tauri/Electron)
 - **M4 Mac Optimized**: Native arm64 build for Apple Silicon
-- **macOS 14+ Support**: Built for modern macOS versions
+- **macOS 13+ Support**: Built for modern macOS versions
 - **Customizable**: Remap any key combination via preferences
 
 ## Installation
@@ -20,7 +20,7 @@ brew install --cask cmd-ime
 ```
 
 ### Manual Installation
-1. Download the latest release from [Releases](https://github.com/kazuki/cmd-ime/releases)
+1. Download the latest release from [Releases](https://github.com/agiletec-inc/cmd-ime/releases)
 2. Move `⌘IME.app` to Applications folder
 3. Right-click and select "Open" (first time only)
 4. Grant accessibility permissions when prompted
@@ -33,14 +33,14 @@ brew install --cask cmd-ime
 Customize key mappings in Preferences (⌘ icon in menu bar → Preferences).
 
 ### Login Item
-- Toggle "ログイン時に開く" from the menu bar or preferences to add/remove a LaunchAgent (`~/Library/LaunchAgents/com.kazuki.cmdime.launcher.plist`) so the app starts at login.
+Toggle **Launch at login** in Preferences → General to register the app with `SMAppService` (the modern macOS API for login items). The state is reflected in System Settings → General → Login Items & Extensions.
 
 ### Updates
-- Toggle "起動時にアップデートを確認" to query GitHub Releases on launch, or press "確認する" in Preferences → 設定 to manually check and open the latest release page.
+Toggle **Check for updates on launch** in Preferences → General, or press **Check Now** at any time. ⌘IME queries the GitHub Releases API and offers to open the download page when a newer version is available.
 
 ## System Requirements
 
-- macOS 14.0 (Sonoma) or later
+- macOS 13.0 (Ventura) or later
 - Apple Silicon (M1/M2/M3/M4) or Intel Mac
 
 ## Building from Source
@@ -54,10 +54,12 @@ Customize key mappings in Preferences (⌘ icon in menu bar → Preferences).
 git clone https://github.com/agiletec-inc/cmd-ime.git
 cd cmd-ime
 
-# Build the Swift menu bar app (bundle via Xcode or swift build)
+# Build the Swift menu bar app
 cd apps/cmd-ime-swift
 swift build -c release
-open CmdIMESwift.xcodeproj   # if you prefer GUI build
+
+# Or build a signed .app bundle ready to drag into /Applications
+./scripts/package.sh
 ```
 
 ## Development
@@ -69,19 +71,15 @@ See [CLAUDE.md](CLAUDE.md) for detailed development documentation.
 Run the automated test suites before shipping any change:
 
 ```bash
-# Swift menu bar app + CmdIME runtime tests
 cd apps/cmd-ime-swift
 swift test
-
-# Xcode scheme (UI tests & unit tests)
-xcodebuild -scheme CmdIMESwift -destination 'platform=macOS,arch=arm64' -skipPackagePluginValidation test
 ```
 
 ## Uninstall
 
 1. Quit the app (menu bar → ⌘ icon → Quit)
 2. Delete `⌘IME.app` from Applications
-3. Remove preferences: `rm ~/Library/Preferences/com.kazuki.cmd-ime.plist`
+3. Remove preferences: `defaults delete com.kazuki.cmdime`
 
 ---
 


### PR DESCRIPTION
## Summary
- README brought in line with reality: macOS 13 minimum, correct `agiletec-inc/cmd-ime` URL, English labels for Login Item / Updates that match the actual `SMAppService` API, no more references to a non-existent `CmdIMESwift.xcodeproj`, fixed uninstall command (bundle id is `com.kazuki.cmdime` not `com.kazuki.cmd-ime`).
- Add `CHANGELOG.md` in Keep a Changelog 1.1.0 format covering 1.2.0 → Unreleased.
- Add `.github/ISSUE_TEMPLATE/{bug_report,feature_request,config}.yml` so new issues collect the right context up front and route general questions to Discussions.

Closes #13

## Test plan
- [x] `cat README.md` reflects all listed fixes.
- [ ] After merge, opening "New issue" on GitHub shows the Bug report / Feature request templates and links to Discussions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)