### PR TITLE
feat: rewrite Preferences UI with SwiftUI

### DIFF
--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/CmdIMEApp.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/CmdIMEApp.swift
@@ -8,40 +8,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let keyEvent = KeyEvent()
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        let userDefaults = UserDefaults.standard
-
-        // Load exclusion apps
-        if let exclusionAppsListData = userDefaults.object(forKey: "exclusionApps") as? [[AnyHashable: Any]] {
-            for val in exclusionAppsListData {
-                if let exclusionApps = AppData(dictionary: val) {
-                    exclusionAppsList.append(exclusionApps)
-                }
-            }
-
-            for val in exclusionAppsList {
-                exclusionAppsDict[val.id] = val.name
-            }
-        }
-
-        // Load key mappings
-        if let keyMappingListData = userDefaults.object(forKey: "mappings") as? [[AnyHashable: Any]] {
-            for val in keyMappingListData {
-                if let mapping = KeyMapping(dictionary: val) {
-                    keyMappingList.append(mapping)
-                }
-            }
-
-            keyMappingListToShortcutList()
-        } else {
-            // Default settings
-            keyMappingList = [
-                KeyMapping(input: KeyboardShortcut(keyCode: 55), output: KeyboardShortcut(keyCode: 102)),
-                KeyMapping(input: KeyboardShortcut(keyCode: 54), output: KeyboardShortcut(keyCode: 104))
-            ]
-
-            saveKeyMappings()
-            keyMappingListToShortcutList()
-        }
+        // Load preferences and apply them to the legacy globals KeyEvent reads.
+        let settings = AppSettings.shared
+        settings.bootstrap()
 
         // Initialize preference window
         preferenceWindowController = PreferenceWindowController.getInstance()
@@ -49,6 +18,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Setup menu
         let menu = NSMenu()
         statusItem.button?.title = "⌘"
+        statusItem.isVisible = settings.showMenuBarIcon
         statusItem.menu = menu
 
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0.0"
@@ -61,13 +31,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         menu.addItem(
             withTitle: "Preferences...",
             action: #selector(AppDelegate.openPreferencesSelector(_:)),
-            keyEquivalent: ""
+            keyEquivalent: ","
         )
         menu.addItem(NSMenuItem.separator())
         menu.addItem(withTitle: "Restart", action: #selector(AppDelegate.restart(_:)), keyEquivalent: "")
-        menu.addItem(withTitle: "Quit", action: #selector(AppDelegate.quit(_:)), keyEquivalent: "")
+        menu.addItem(withTitle: "Quit", action: #selector(AppDelegate.quit(_:)), keyEquivalent: "q")
 
         keyEvent.start()
+
+        if settings.checkUpdateAtLaunch {
+            checkUpdate()
+        }
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/KeyEvent.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/KeyEvent.swift
@@ -140,7 +140,7 @@ class KeyEvent: NSObject {
     }
 
     func eventCallback(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
-        if isExclusionApp {
+        if isExclusionApp || isRecordingShortcut {
             return Unmanaged.passRetained(event)
         }
 

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/PreferenceWindowController.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/PreferenceWindowController.swift
@@ -2,72 +2,38 @@
 //  PreferenceWindowController.swift
 //  ⌘IME
 //
-//  MIT License
-//  Copyright (c) 2016 iMasanari
+//  Hosts the SwiftUI Settings UI inside an AppKit window so the menu bar
+//  agent can present and reuse it without spinning up a full Settings scene.
 //
 
 import Cocoa
+import SwiftUI
 
-class PreferenceWindowController: NSWindowController, NSWindowDelegate {
+final class PreferenceWindowController: NSWindowController, NSWindowDelegate {
     static func getInstance() -> PreferenceWindowController {
-        // Create window programmatically without Storyboard
+        let hosting = NSHostingController(
+            rootView: SettingsView().environmentObject(AppSettings.shared)
+        )
+
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
-            styleMask: [.titled, .closable, .miniaturizable],
+            contentRect: NSRect(x: 0, y: 0, width: 540, height: 420),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
             backing: .buffered,
             defer: false
         )
-        window.title = "⌘IME"
+        window.title = "⌘IME Preferences"
+        window.contentViewController = hosting
         window.center()
         window.isReleasedWhenClosed = false
 
         let controller = PreferenceWindowController(window: window)
         window.delegate = controller
-
-        // Create a simple tab view with two tabs
-        let tabView = NSTabView(frame: NSRect(x: 0, y: 0, width: 480, height: 320))
-
-        // General tab
-        let generalTabItem = NSTabViewItem(identifier: "general")
-        generalTabItem.label = "General"
-        let generalView = NSView(frame: NSRect(x: 0, y: 0, width: 460, height: 300))
-
-        let label = NSTextField(labelWithString: "⌘IME Settings")
-        label.frame = NSRect(x: 20, y: 260, width: 420, height: 20)
-        label.font = NSFont.systemFont(ofSize: 14, weight: .bold)
-        generalView.addSubview(label)
-
-        let infoLabel = NSTextField(labelWithString: "Press Preferences menu to configure key mappings")
-        infoLabel.frame = NSRect(x: 20, y: 220, width: 420, height: 20)
-        generalView.addSubview(infoLabel)
-
-        generalTabItem.view = generalView
-        tabView.addTabViewItem(generalTabItem)
-
-        // Shortcuts tab
-        let shortcutsTabItem = NSTabViewItem(identifier: "shortcuts")
-        shortcutsTabItem.label = "Shortcuts"
-        let shortcutsView = NSView(frame: NSRect(x: 0, y: 0, width: 460, height: 300))
-
-        let shortcutsLabel = NSTextField(labelWithString: "Key mappings configuration")
-        shortcutsLabel.frame = NSRect(x: 20, y: 260, width: 420, height: 20)
-        shortcutsLabel.font = NSFont.systemFont(ofSize: 14, weight: .bold)
-        shortcutsView.addSubview(shortcutsLabel)
-
-        shortcutsTabItem.view = shortcutsView
-        tabView.addTabViewItem(shortcutsTabItem)
-
-        window.contentView = tabView
-
         return controller
     }
 
     func showAndActivate(_ sender: AnyObject?) {
-        self.showWindow(sender)
-        self.window?.makeKeyAndOrderFront(sender)
+        showWindow(sender)
+        window?.makeKeyAndOrderFront(sender)
         NSApp.activate(ignoringOtherApps: true)
-    }
-    override func mouseDown(with event: NSEvent) {
-        activeKeyTextField?.blur()
     }
 }

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/AppSettings.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/AppSettings.swift
@@ -1,0 +1,195 @@
+//
+//  AppSettings.swift
+//  ⌘IME
+//
+//  Single source of truth for user-facing preferences. Wraps UserDefaults
+//  and SMAppService and keeps the legacy globals consumed by KeyEvent
+//  (`keyMappingList`, `shortcutList`, `exclusionAppsList`, `exclusionAppsDict`)
+//  in sync with the published state.
+//
+
+import Cocoa
+import Combine
+import ServiceManagement
+import SwiftUI
+
+@MainActor
+final class AppSettings: ObservableObject {
+    static let shared = AppSettings()
+
+    enum Keys {
+        static let launchAtStartup = "launchAtStartup"
+        static let legacyLaunchAtStartup = "lunchAtStartup"
+        static let showMenuBarIcon = "showIcon"
+        static let checkUpdateAtLaunch = "checkUpdateAtLaunch"
+        static let legacyCheckUpdateAtLaunch = "checkUpdateAtlaunch"
+        static let keyMappings = "mappings"
+        static let exclusionApps = "exclusionApps"
+    }
+
+    private let defaults: UserDefaults
+
+    @Published var launchAtStartup: Bool
+    @Published var showMenuBarIcon: Bool
+    @Published var checkUpdateAtLaunch: Bool
+    @Published var keyMappings: [KeyMapping]
+    @Published var exclusionApps: [AppData]
+
+    private var cancellables: Set<AnyCancellable> = []
+    private var isApplyingExternalUpdate = false
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+
+        Self.migrateLegacyKeys(in: defaults)
+
+        self.showMenuBarIcon = (defaults.object(forKey: Keys.showMenuBarIcon) as? Int ?? 1) != 0
+        self.checkUpdateAtLaunch = (defaults.object(forKey: Keys.checkUpdateAtLaunch) as? Int ?? 1) != 0
+
+        let stored = (defaults.object(forKey: Keys.launchAtStartup) as? Int ?? 0) != 0
+        let serviceEnabled = SMAppService.mainApp.status == .enabled
+        self.launchAtStartup = stored || serviceEnabled
+
+        self.keyMappings = Self.loadKeyMappings(from: defaults)
+        self.exclusionApps = Self.loadExclusionApps(from: defaults)
+
+        publishGlobalsFromState()
+        observePropertyChanges()
+    }
+
+    /// Call once on app launch to reconcile any drift between SMAppService
+    /// (the OS-side login item registry) and our stored toggle.
+    func bootstrap() {
+        let serviceEnabled = SMAppService.mainApp.status == .enabled
+        if launchAtStartup && !serviceEnabled {
+            // Stored intent is "on" (incl. migrated legacy value) but the OS
+            // never registered us — register now so the next login honors it.
+            setLaunchAtStartup(true)
+        } else if !launchAtStartup && serviceEnabled {
+            // OS already registered us (e.g. enabled in System Settings) but
+            // the stored toggle is off. Follow the OS state.
+            launchAtStartup = true
+        }
+    }
+
+    // MARK: - Mutators surfaced to SwiftUI
+
+    func addKeyMapping() {
+        keyMappings.append(KeyMapping())
+    }
+
+    func removeKeyMapping(at index: Int) {
+        guard keyMappings.indices.contains(index) else { return }
+        keyMappings.remove(at: index)
+    }
+
+    func moveKeyMapping(from source: IndexSet, to destination: Int) {
+        keyMappings.move(fromOffsets: source, toOffset: destination)
+    }
+
+    func updateKeyMapping(at index: Int, input: KeyboardShortcut? = nil, output: KeyboardShortcut? = nil) {
+        guard keyMappings.indices.contains(index) else { return }
+        if let input = input { keyMappings[index].input = input }
+        if let output = output { keyMappings[index].output = output }
+        keyMappings = keyMappings  // trigger didSet
+    }
+
+    func addExclusion(_ app: AppData) {
+        guard !exclusionApps.contains(where: { $0.id == app.id }) else { return }
+        exclusionApps.append(app)
+    }
+
+    func removeExclusion(at index: Int) {
+        guard exclusionApps.indices.contains(index) else { return }
+        exclusionApps.remove(at: index)
+    }
+
+    // MARK: - Internals
+
+    private func observePropertyChanges() {
+        $launchAtStartup
+            .dropFirst()
+            .sink { [weak self] newValue in
+                guard let self = self, !self.isApplyingExternalUpdate else { return }
+                self.defaults.set(newValue ? 1 : 0, forKey: Keys.launchAtStartup)
+                setLaunchAtStartup(newValue)
+            }
+            .store(in: &cancellables)
+
+        $showMenuBarIcon
+            .dropFirst()
+            .sink { [weak self] newValue in
+                guard let self = self else { return }
+                self.defaults.set(newValue ? 1 : 0, forKey: Keys.showMenuBarIcon)
+                statusItem.isVisible = newValue
+            }
+            .store(in: &cancellables)
+
+        $checkUpdateAtLaunch
+            .dropFirst()
+            .sink { [weak self] newValue in
+                self?.defaults.set(newValue ? 1 : 0, forKey: Keys.checkUpdateAtLaunch)
+            }
+            .store(in: &cancellables)
+
+        $keyMappings
+            .dropFirst()
+            .sink { [weak self] mappings in
+                guard let self = self else { return }
+                self.defaults.set(mappings.map { $0.toDictionary() }, forKey: Keys.keyMappings)
+                keyMappingList = mappings
+                keyMappingListToShortcutList()
+            }
+            .store(in: &cancellables)
+
+        $exclusionApps
+            .dropFirst()
+            .sink { [weak self] apps in
+                guard let self = self else { return }
+                self.defaults.set(apps.map { $0.toDictionary() }, forKey: Keys.exclusionApps)
+                exclusionAppsList = apps
+                exclusionAppsDict = Dictionary(uniqueKeysWithValues: apps.map { ($0.id, $0.name) })
+            }
+            .store(in: &cancellables)
+    }
+
+    private func publishGlobalsFromState() {
+        keyMappingList = keyMappings
+        keyMappingListToShortcutList()
+        exclusionAppsList = exclusionApps
+        exclusionAppsDict = Dictionary(uniqueKeysWithValues: exclusionApps.map { ($0.id, $0.name) })
+    }
+
+    private static func migrateLegacyKeys(in defaults: UserDefaults) {
+        if defaults.object(forKey: Keys.launchAtStartup) == nil,
+           let legacy = defaults.object(forKey: Keys.legacyLaunchAtStartup) {
+            defaults.set(legacy, forKey: Keys.launchAtStartup)
+            defaults.removeObject(forKey: Keys.legacyLaunchAtStartup)
+        }
+        if defaults.object(forKey: Keys.checkUpdateAtLaunch) == nil,
+           let legacy = defaults.object(forKey: Keys.legacyCheckUpdateAtLaunch) {
+            defaults.set(legacy, forKey: Keys.checkUpdateAtLaunch)
+            defaults.removeObject(forKey: Keys.legacyCheckUpdateAtLaunch)
+        }
+    }
+
+    private static func loadKeyMappings(from defaults: UserDefaults) -> [KeyMapping] {
+        if let raw = defaults.object(forKey: Keys.keyMappings) as? [[AnyHashable: Any]] {
+            let parsed = raw.compactMap { KeyMapping(dictionary: $0) }
+            if !parsed.isEmpty { return parsed }
+        }
+        return Self.defaultKeyMappings
+    }
+
+    private static func loadExclusionApps(from defaults: UserDefaults) -> [AppData] {
+        guard let raw = defaults.object(forKey: Keys.exclusionApps) as? [[AnyHashable: Any]] else {
+            return []
+        }
+        return raw.compactMap { AppData(dictionary: $0) }
+    }
+
+    static let defaultKeyMappings: [KeyMapping] = [
+        KeyMapping(input: KeyboardShortcut(keyCode: 55), output: KeyboardShortcut(keyCode: 102)),
+        KeyMapping(input: KeyboardShortcut(keyCode: 54), output: KeyboardShortcut(keyCode: 104))
+    ]
+}

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/ExclusionsSettingsView.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/ExclusionsSettingsView.swift
@@ -1,0 +1,109 @@
+//
+//  ExclusionsSettingsView.swift
+//  ⌘IME
+//
+//  Manages the list of apps in which ⌘IME's key remapping is suppressed.
+//
+
+import SwiftUI
+
+struct ExclusionsSettingsView: View {
+    @EnvironmentObject private var settings: AppSettings
+    @State private var recentApps: [AppData] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("⌘IME will not remap keys when these apps are frontmost.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            sectionHeader("Excluded")
+            if settings.exclusionApps.isEmpty {
+                emptyRow("No excluded apps yet.")
+            } else {
+                List {
+                    ForEach(Array(settings.exclusionApps.enumerated()), id: \.offset) { index, app in
+                        HStack {
+                            appIcon(for: app)
+                            VStack(alignment: .leading) {
+                                Text(app.name)
+                                Text(app.id).font(.caption).foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Button(role: .destructive) {
+                                settings.removeExclusion(at: index)
+                            } label: {
+                                Image(systemName: "minus.circle")
+                            }
+                            .buttonStyle(.borderless)
+                        }
+                    }
+                }
+                .frame(minHeight: 100)
+            }
+
+            sectionHeader("Recently active")
+            if recentApps.isEmpty {
+                emptyRow("Switch to another app and come back to populate this list.")
+            } else {
+                List {
+                    ForEach(recentApps, id: \.id) { app in
+                        HStack {
+                            appIcon(for: app)
+                            VStack(alignment: .leading) {
+                                Text(app.name)
+                                Text(app.id).font(.caption).foregroundStyle(.secondary)
+                            }
+                            Spacer()
+                            Button {
+                                settings.addExclusion(app)
+                            } label: {
+                                Image(systemName: "plus.circle")
+                            }
+                            .buttonStyle(.borderless)
+                            .disabled(settings.exclusionApps.contains(where: { $0.id == app.id }))
+                        }
+                    }
+                }
+                .frame(minHeight: 100)
+            }
+        }
+        .onAppear { reloadRecent() }
+        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
+            reloadRecent()
+        }
+    }
+
+    private func reloadRecent() {
+        let excludedIDs = Set(settings.exclusionApps.map { $0.id })
+        recentApps = activeAppsList.filter { !excludedIDs.contains($0.id) }
+    }
+
+    @ViewBuilder
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title)
+            .font(.headline)
+            .padding(.top, 4)
+    }
+
+    @ViewBuilder
+    private func emptyRow(_ message: String) -> some View {
+        Text(message)
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private func appIcon(for app: AppData) -> some View {
+        if let nsImage = NSWorkspace.shared.urlForApplication(withBundleIdentifier: app.id)
+            .map({ NSWorkspace.shared.icon(forFile: $0.path) }) {
+            Image(nsImage: nsImage)
+                .resizable()
+                .frame(width: 24, height: 24)
+        } else {
+            Image(systemName: "app")
+                .frame(width: 24, height: 24)
+        }
+    }
+}

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/GeneralSettingsView.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/GeneralSettingsView.swift
@@ -1,0 +1,50 @@
+//
+//  GeneralSettingsView.swift
+//  ⌘IME
+//
+
+import SwiftUI
+
+struct GeneralSettingsView: View {
+    @EnvironmentObject private var settings: AppSettings
+    @State private var isCheckingForUpdates = false
+
+    private var version: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                Toggle("Launch at login", isOn: $settings.launchAtStartup)
+                Toggle("Show menu bar icon", isOn: $settings.showMenuBarIcon)
+            }
+
+            Section {
+                Toggle("Check for updates on launch", isOn: $settings.checkUpdateAtLaunch)
+                HStack {
+                    Button {
+                        runManualUpdateCheck()
+                    } label: {
+                        if isCheckingForUpdates {
+                            ProgressView().controlSize(.small)
+                        } else {
+                            Text("Check Now")
+                        }
+                    }
+                    .disabled(isCheckingForUpdates)
+                    Spacer()
+                    Text("Version \(version)").foregroundStyle(.secondary)
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func runManualUpdateCheck() {
+        isCheckingForUpdates = true
+        checkUpdate(manual: true) { _ in
+            isCheckingForUpdates = false
+        }
+    }
+}

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/KeyRecorderSheet.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/KeyRecorderSheet.swift
@@ -1,0 +1,123 @@
+//
+//  KeyRecorderSheet.swift
+//  ⌘IME
+//
+//  Modal sheet that captures a single key press (with modifiers) and
+//  reports it back as a `KeyboardShortcut`. Uses NSEvent local monitors
+//  rather than the global CGEvent tap so the key never leaks to the
+//  rest of the system while the user is recording.
+//
+
+import SwiftUI
+import Cocoa
+
+/// While true, KeyEvent's CGEvent tap leaves keys unmodified so that
+/// the recorder sheet captures them without firing the IME switch.
+var isRecordingShortcut: Bool = false
+
+struct KeyRecorderSheet: View {
+    let title: String
+    let allowModifierOnly: Bool
+    let initial: KeyboardShortcut
+    let onCommit: (KeyboardShortcut) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var captured: KeyboardShortcut
+
+    init(title: String,
+         allowModifierOnly: Bool,
+         initial: KeyboardShortcut,
+         onCommit: @escaping (KeyboardShortcut) -> Void) {
+        self.title = title
+        self.allowModifierOnly = allowModifierOnly
+        self.initial = initial
+        self.onCommit = onCommit
+        self._captured = State(initialValue: initial)
+    }
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text(title).font(.headline)
+
+            Text(captured.toString().isEmpty ? "Press a key…" : captured.toString())
+                .font(.system(size: 32, weight: .medium, design: .rounded))
+                .frame(maxWidth: .infinity, minHeight: 80)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(Color(NSColor.textBackgroundColor))
+                )
+
+            HStack {
+                Button("Cancel") { dismiss() }
+                    .keyboardShortcut(.cancelAction)
+                Spacer()
+                Button("Save") {
+                    onCommit(captured)
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+                .disabled(captured.toString().isEmpty)
+            }
+        }
+        .padding(24)
+        .frame(width: 360)
+        .background(KeyRecorderHost(allowModifierOnly: allowModifierOnly,
+                                     captured: $captured))
+    }
+}
+
+/// Invisible NSView that installs local NSEvent monitors on appear and
+/// tears them down on disappear. Reports captured shortcuts via binding.
+private struct KeyRecorderHost: NSViewRepresentable {
+    let allowModifierOnly: Bool
+    @Binding var captured: KeyboardShortcut
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        context.coordinator.attach(allowModifierOnly: allowModifierOnly,
+                                    binding: $captured)
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator {
+        private var keyMonitor: Any?
+        private var flagsMonitor: Any?
+
+        deinit { detach() }
+
+        func attach(allowModifierOnly: Bool, binding: Binding<KeyboardShortcut>) {
+            detach()
+            isRecordingShortcut = true
+            keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+                let shortcut = KeyboardShortcut(
+                    keyCode: CGKeyCode(event.keyCode),
+                    flags: CGEventFlags(rawValue: UInt64(event.modifierFlags.rawValue))
+                )
+                binding.wrappedValue = shortcut
+                return nil  // swallow the key
+            }
+            if allowModifierOnly {
+                flagsMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
+                    let shortcut = KeyboardShortcut(
+                        keyCode: CGKeyCode(event.keyCode),
+                        flags: CGEventFlags(rawValue: UInt64(event.modifierFlags.rawValue))
+                    )
+                    binding.wrappedValue = shortcut
+                    return event
+                }
+            }
+        }
+
+        func detach() {
+            if let monitor = keyMonitor { NSEvent.removeMonitor(monitor) }
+            if let monitor = flagsMonitor { NSEvent.removeMonitor(monitor) }
+            keyMonitor = nil
+            flagsMonitor = nil
+            isRecordingShortcut = false
+        }
+    }
+}

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/SettingsView.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/SettingsView.swift
@@ -1,0 +1,52 @@
+//
+//  SettingsView.swift
+//  ⌘IME
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject private var settings: AppSettings
+
+    enum Tab: String, Hashable, CaseIterable {
+        case general
+        case shortcuts
+        case exclusions
+
+        var label: String {
+            switch self {
+            case .general: return "General"
+            case .shortcuts: return "Shortcuts"
+            case .exclusions: return "Exclusions"
+            }
+        }
+
+        var systemImage: String {
+            switch self {
+            case .general: return "gearshape"
+            case .shortcuts: return "keyboard"
+            case .exclusions: return "minus.circle"
+            }
+        }
+    }
+
+    @State private var selection: Tab = .general
+
+    var body: some View {
+        TabView(selection: $selection) {
+            GeneralSettingsView()
+                .tabItem { Label(Tab.general.label, systemImage: Tab.general.systemImage) }
+                .tag(Tab.general)
+
+            ShortcutsSettingsView()
+                .tabItem { Label(Tab.shortcuts.label, systemImage: Tab.shortcuts.systemImage) }
+                .tag(Tab.shortcuts)
+
+            ExclusionsSettingsView()
+                .tabItem { Label(Tab.exclusions.label, systemImage: Tab.exclusions.systemImage) }
+                .tag(Tab.exclusions)
+        }
+        .frame(minWidth: 520, minHeight: 360)
+        .padding(20)
+    }
+}

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/ShortcutsSettingsView.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/ShortcutsSettingsView.swift
@@ -1,0 +1,101 @@
+//
+//  ShortcutsSettingsView.swift
+//  ⌘IME
+//
+
+import SwiftUI
+
+struct ShortcutsSettingsView: View {
+    @EnvironmentObject private var settings: AppSettings
+    @State private var selectedRowID: UUID?
+    @State private var rowEditing: RowEdit?
+
+    private struct RowEdit: Identifiable {
+        let id = UUID()
+        let index: Int
+        let field: Field
+        enum Field { case input, output }
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Text("Tap a row to record a new key. Modifier-only inputs (e.g. left ⌘) are allowed for Input.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            List {
+                ForEach(Array(settings.keyMappings.enumerated()), id: \.offset) { index, mapping in
+                    HStack(spacing: 12) {
+                        recordingCell(label: mapping.input.toString(),
+                                       placeholder: "Input",
+                                       index: index,
+                                       field: .input)
+                        Image(systemName: "arrow.right").foregroundStyle(.secondary)
+                        recordingCell(label: mapping.output.toString(),
+                                       placeholder: "Output",
+                                       index: index,
+                                       field: .output)
+                        Spacer()
+                        Button(role: .destructive) {
+                            settings.removeKeyMapping(at: index)
+                        } label: {
+                            Image(systemName: "minus.circle")
+                        }
+                        .buttonStyle(.borderless)
+                        .help("Remove this mapping")
+                    }
+                    .padding(.vertical, 4)
+                }
+            }
+            .frame(minHeight: 200)
+
+            HStack {
+                Button {
+                    settings.addKeyMapping()
+                } label: {
+                    Label("Add", systemImage: "plus")
+                }
+                Spacer()
+            }
+        }
+        .sheet(item: $rowEditing) { edit in
+            KeyRecorderSheet(
+                title: edit.field == .input ? "Record Input" : "Record Output",
+                allowModifierOnly: edit.field == .input,
+                initial: edit.field == .input
+                    ? settings.keyMappings[edit.index].input
+                    : settings.keyMappings[edit.index].output,
+                onCommit: { shortcut in
+                    if edit.field == .input {
+                        settings.updateKeyMapping(at: edit.index, input: shortcut)
+                    } else {
+                        settings.updateKeyMapping(at: edit.index, output: shortcut)
+                    }
+                }
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func recordingCell(label: String, placeholder: String, index: Int, field: RowEdit.Field) -> some View {
+        Button {
+            rowEditing = RowEdit(index: index, field: field)
+        } label: {
+            Text(label.isEmpty ? placeholder : label)
+                .frame(minWidth: 100, alignment: .leading)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(Color(NSColor.textBackgroundColor))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color(NSColor.separatorColor), lineWidth: 1)
+                )
+                .foregroundStyle(label.isEmpty ? Color.secondary : Color.primary)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/checkUpdate.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/checkUpdate.swift
@@ -3,67 +3,106 @@
 //  ⌘IME
 //
 //  MIT License
-//  Copyright (c) 2016 iMasanari
 //
-
-// TODO: NSURLSessionでの書き直し
-// NSURLConnection.sendAsynchronousRequestはdeprecatedだが
-// NSURLSessionを使うと実行時にalert.runModal()でエラーが出たため
-// NSURLConnectionで代用中
 
 import Cocoa
 
-func checkUpdate(_ callback: ((_ isNewVer: Bool?) -> Void)? = nil) {
-    let url = URL(string: "https://ei-kana.appspot.com/update.json")!
-    let request = URLRequest(url: url)
+private let releasesAPIURL = URL(
+    string: "https://api.github.com/repos/agiletec-inc/cmd-ime/releases/latest"
+)!
 
-    let handler = { (data: Data?, _: URLResponse?, error: Error?) in
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
-        var newVersion = ""
-        var description = ""
-        var url = "https://ei-kana.appspot.com"
+/// Check GitHub for a newer release. Calls back on the main queue.
+///
+/// - Parameters:
+///   - manual: when `true`, also surface an alert if the app is up to date
+///     or the request fails. Set to `false` for the silent on-launch check.
+///   - callback: invoked with `true` if a newer version is available,
+///     `false` if up to date, and `nil` on network/parse error.
+func checkUpdate(manual: Bool = false, _ callback: ((_ isNewVer: Bool?) -> Void)? = nil) {
+    let currentVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
 
-        do {
-            if let data = data,
-               let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                newVersion = json["version"] as? String ?? ""
-                description = json["description"] as? String ?? ""
+    var request = URLRequest(url: releasesAPIURL)
+    request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+    request.setValue("CmdIME/\(currentVersion)", forHTTPHeaderField: "User-Agent")
+    request.timeoutInterval = 10
 
-                if let downloadURL = json["url"] as? String {
-                    url = downloadURL
-                }
-            }
-        } catch let error as NSError {
-            print(error.debugDescription)
-            return
-        }
+    URLSession.shared.dataTask(with: request) { data, response, _ in
+        let result = parseLatestRelease(data: data, response: response)
 
         DispatchQueue.main.async {
-            let isAbleUpdate: Bool? = (newVersion == "") ? nil : newVersion != version
-
-            if isAbleUpdate == true {
-                let alert = NSAlert()
-                alert.messageText = "⌘IME ver.\(newVersion) が利用可能です"
-                alert.informativeText = description
-                alert.addButton(withTitle: "Download")
-                alert.addButton(withTitle: "Cancel")
-                // alert.showsSuppressionButton = true;
-                let ret = alert.runModal()
-
-                if ret == NSApplication.ModalResponse.alertFirstButtonReturn {
-                    NSWorkspace.shared.open(URL(string: url)!)
+            switch result {
+            case .failure:
+                if manual {
+                    let alert = NSAlert()
+                    alert.messageText = "Could not check for updates"
+                    alert.informativeText = "Please check your network connection and try again."
+                    alert.runModal()
                 }
-            }
+                callback?(nil)
 
-            if let callback = callback {
-                callback(isAbleUpdate)
+            case .success(let release):
+                let hasNewer = isNewer(latest: release.version, current: currentVersion)
+
+                if hasNewer {
+                    let alert = NSAlert()
+                    alert.messageText = "⌘IME \(release.version) is available"
+                    alert.informativeText = release.notes.isEmpty
+                        ? "A newer version is available on GitHub."
+                        : release.notes
+                    alert.addButton(withTitle: "Download")
+                    alert.addButton(withTitle: "Later")
+                    if alert.runModal() == .alertFirstButtonReturn {
+                        NSWorkspace.shared.open(release.url)
+                    }
+                } else if manual {
+                    let alert = NSAlert()
+                    alert.messageText = "⌘IME is up to date"
+                    alert.informativeText = "You are running version \(currentVersion)."
+                    alert.runModal()
+                }
+
+                callback?(hasNewer)
             }
         }
+    }.resume()
+}
+
+private struct LatestRelease {
+    let version: String
+    let url: URL
+    let notes: String
+}
+
+private enum Result {
+    case success(LatestRelease)
+    case failure
+}
+
+private func parseLatestRelease(data: Data?, response: URLResponse?) -> Result {
+    guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode),
+          let data = data,
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let tag = json["tag_name"] as? String,
+          let urlString = json["html_url"] as? String,
+          let url = URL(string: urlString)
+    else {
+        return .failure
     }
 
-    // NSURLConnection.sendAsynchronousRequest(request, queue: OperationQueue.main, completionHandler: handler)
-    let config = URLSessionConfiguration.default
-    let session = URLSession(configuration: config)
-    let task = session.dataTask(with: request, completionHandler: handler)
-    task.resume()
+    let version = tag.hasPrefix("v") ? String(tag.dropFirst()) : tag
+    let notes = (json["body"] as? String) ?? ""
+    return .success(LatestRelease(version: version, url: url, notes: notes))
+}
+
+/// Semver-aware comparison. Returns true when `latest` is strictly greater than `current`.
+private func isNewer(latest: String, current: String) -> Bool {
+    let latestParts = latest.split(separator: ".").compactMap { Int($0) }
+    let currentParts = current.split(separator: ".").compactMap { Int($0) }
+    let count = max(latestParts.count, currentParts.count)
+    for i in 0..<count {
+        let l = i < latestParts.count ? latestParts[i] : 0
+        let c = i < currentParts.count ? currentParts[i] : 0
+        if l != c { return l > c }
+    }
+    return false
 }


### PR DESCRIPTION
## Summary

Replace the empty stub `PreferenceWindowController` with a SwiftUI-based Settings window and centralize all preferences behind a single `AppSettings` ObservableObject. Three working tabs:

- **General** — Launch at login (SMAppService), Show menu bar icon, Check for updates on launch, Check Now button, version line.
- **Shortcuts** — Editable list of key mappings with a key-recording sheet. While recording, the global CGEvent tap is gated so the captured key doesn't trigger an IME switch.
- **Exclusions** — Add/remove apps from the exclusion list, with recent-app discovery.

## Migration

- `lunchAtStartup` → `launchAtStartup` (typo fix from #3).
- `checkUpdateAtlaunch` → `checkUpdateAtLaunch`.

Both run once on first launch; legacy keys are removed after the value moves.

## Closes

- #2 (Preferences was a non-functional stub)
- #3 (UserDefaults typo)
- #7 (this PR)

## Stack

This PR is stacked on top of #15 (`fix/issue-4-update-endpoint`) because the new General tab calls `checkUpdate(manual: true)`. Merge #15 first.

## Test plan

- [x] `swift build -c release` clean.
- [x] `swift test` — 4/4 pass.
- [x] `bash scripts/package.sh` produces `.build/release/CmdIME.app` (signed ad-hoc).
- [ ] Manual smoke (after merge):
  - [ ] Launch the app, click ⌘ menu → Preferences → window opens with three tabs.
  - [ ] Toggle "Launch at login" → System Settings → General → Login Items reflects the change. Toggle off → entry disappears.
  - [ ] "Show menu bar icon" toggle hides/shows the ⌘ icon.
  - [ ] Shortcuts tab: existing Cmd_L→英数 / Cmd_R→かな mappings render. Add a row, hit "Record" on Input, press a modifier (e.g. ⌥), Save. The new mapping persists across restart (`defaults read com.kazuki.cmdime mappings`).
  - [ ] Exclusions tab: switch to another app and back → it appears in "Recently active". Click + → moves to "Excluded". When that app is frontmost, ⌘IME no longer remaps keys.
  - [ ] "Check Now" alerts with the latest GitHub release info.
  - [ ] Pre-seed `defaults write com.kazuki.cmdime lunchAtStartup -int 1` → relaunch → `defaults read com.kazuki.cmdime` shows `launchAtStartup = 1` and the legacy key is gone.

## Out of scope (follow-up issues)

- Removing dead `ViewController.swift`, `ExclusionAppsController.swift`, `Resources/Base.lproj/Main.storyboard`, and the rest of `KeyTextField.swift`/`ShortcutsController.swift` plumbing → tracked in #11.
- Removing the macOS-12 `SMLoginItemSetEnabled` branch → #10.
- `manifest.toml`-driven version → #9.
- Test coverage for the new code → #12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)