### PR TITLE
chore: derive Info.plist version from manifest.toml

### DIFF
--- a/apps/cmd-ime-swift/scripts/package.sh
+++ b/apps/cmd-ime-swift/scripts/package.sh
@@ -13,7 +13,23 @@ RESOURCES_DIR="$APP_DIR/Contents/Resources"
 INFO_PLIST="$APP_DIR/Contents/Info.plist"
 ICON_SOURCE="$PROJECT_ROOT/../../AppIcon.icns"
 
-VERSION="${CMD_IME_VERSION:-$(git -C "$PROJECT_ROOT" describe --tags --always 2>/dev/null || echo "0.0.0")}"
+resolve_version() {
+    if [[ -n "${CMD_IME_VERSION:-}" ]]; then
+        printf '%s' "$CMD_IME_VERSION"
+        return
+    fi
+    local manifest="$PROJECT_ROOT/../../manifest.toml"
+    if [[ -f "$manifest" ]]; then
+        local v
+        v=$(awk -F'"' '/^version[[:space:]]*=/ {print $2; exit}' "$manifest" 2>/dev/null)
+        if [[ -n "$v" ]]; then
+            printf '%s' "$v"
+            return
+        fi
+    fi
+    git -C "$PROJECT_ROOT" describe --tags --always 2>/dev/null || printf '0.0.0'
+}
+VERSION="$(resolve_version)"
 
 echo ">> Building Swift release binary"
 swift build -c release --package-path "$PROJECT_ROOT"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,6 +3,7 @@
 [project]
 id = "cmd-ime"
 name = "⌘IME"
+version = "1.2.5"
 description = "Lightweight macOS app for switching between alphanumeric and kana input using Command keys"
 authors = ["Kazuki <kazuki@agiletec.jp>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
- Add `[project].version = \"1.2.5\"` to `manifest.toml` so it actually has the field the project's CLAUDE.md says is the source of truth.
- `scripts/package.sh` now resolves the version in this order: env `CMD_IME_VERSION` → `manifest.toml` → `git describe` → `0.0.0`.
- CI's `release.yml` already sets `CMD_IME_VERSION` so the conventional-commits-driven auto-bump keeps working untouched.

Closes #9

## Test plan
- [x] `bash scripts/package.sh` → `Info.plist` shows `1.2.5`.
- [x] `CMD_IME_VERSION=9.9.9-test bash scripts/package.sh` → `Info.plist` shows `9.9.9-test`.
- [ ] Next merge to main → `release.yml` produces a release with the conventional-commits-derived version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)