### PR TITLE
test: cover KeyboardShortcut, KeyMapping, AppSettings persistence

### DIFF
--- a/apps/cmd-ime-swift/Tests/CmdIMESwiftTests/AppSettingsTests.swift
+++ b/apps/cmd-ime-swift/Tests/CmdIMESwiftTests/AppSettingsTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import CmdIMESwift
+
+@MainActor
+final class AppSettingsTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        suiteName = "test.cmdime.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        // Reset legacy globals KeyEvent reads.
+        keyMappingList = []
+        shortcutList = [:]
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        try await super.tearDown()
+    }
+
+    func testMigratesLegacyLaunchAtStartupKey() {
+        defaults.set(1, forKey: "lunchAtStartup")  // legacy typo
+
+        _ = AppSettings(defaults: defaults)
+
+        XCTAssertEqual(defaults.object(forKey: "launchAtStartup") as? Int, 1)
+        XCTAssertNil(defaults.object(forKey: "lunchAtStartup"))
+    }
+
+    func testMigratesLegacyCheckUpdateAtLaunchKey() {
+        defaults.set(0, forKey: "checkUpdateAtlaunch")  // legacy lower-case "l"
+
+        _ = AppSettings(defaults: defaults)
+
+        XCTAssertEqual(defaults.object(forKey: "checkUpdateAtLaunch") as? Int, 0)
+        XCTAssertNil(defaults.object(forKey: "checkUpdateAtlaunch"))
+    }
+
+    func testLoadsDefaultKeyMappingsWhenNoneStored() {
+        let settings = AppSettings(defaults: defaults)
+
+        XCTAssertEqual(settings.keyMappings.count, 2)
+        XCTAssertEqual(settings.keyMappings[0].input.keyCode, 55)   // Cmd_L
+        XCTAssertEqual(settings.keyMappings[0].output.keyCode, 102) // 英数
+        XCTAssertEqual(settings.keyMappings[1].input.keyCode, 54)   // Cmd_R
+        XCTAssertEqual(settings.keyMappings[1].output.keyCode, 104) // かな
+    }
+
+    func testKeyMappingMutationPersistsAndUpdatesGlobals() {
+        let settings = AppSettings(defaults: defaults)
+        let initialCount = settings.keyMappings.count
+
+        settings.addKeyMapping()
+        XCTAssertEqual(settings.keyMappings.count, initialCount + 1)
+
+        // didSet fires synchronously; legacy globals must be updated.
+        XCTAssertEqual(keyMappingList.count, initialCount + 1)
+
+        // Persisted to UserDefaults under the canonical key.
+        let stored = defaults.object(forKey: "mappings") as? [[AnyHashable: Any]]
+        XCTAssertEqual(stored?.count, initialCount + 1)
+    }
+
+    func testRemoveKeyMappingPersistsRemoval() {
+        let settings = AppSettings(defaults: defaults)
+        settings.removeKeyMapping(at: 0)
+
+        XCTAssertEqual(settings.keyMappings.count, 1)
+        XCTAssertEqual(keyMappingList.count, 1)
+    }
+
+    func testExclusionMutationsPropagateToGlobals() {
+        let settings = AppSettings(defaults: defaults)
+        let app = AppData(name: "Code", id: "com.microsoft.VSCode")
+
+        settings.addExclusion(app)
+
+        XCTAssertEqual(settings.exclusionApps.count, 1)
+        XCTAssertEqual(exclusionAppsList.count, 1)
+        XCTAssertEqual(exclusionAppsDict["com.microsoft.VSCode"], "Code")
+
+        // Adding the same app twice is a no-op.
+        settings.addExclusion(app)
+        XCTAssertEqual(settings.exclusionApps.count, 1)
+
+        settings.removeExclusion(at: 0)
+        XCTAssertEqual(settings.exclusionApps.count, 0)
+        XCTAssertEqual(exclusionAppsList.count, 0)
+        XCTAssertNil(exclusionAppsDict["com.microsoft.VSCode"])
+    }
+}

--- a/apps/cmd-ime-swift/Tests/CmdIMESwiftTests/KeyMappingTests.swift
+++ b/apps/cmd-ime-swift/Tests/CmdIMESwiftTests/KeyMappingTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import CmdIMESwift
+
+final class KeyMappingTests: XCTestCase {
+
+    func testDictionaryRoundTrip() {
+        let mapping = KeyMapping(
+            input: KeyboardShortcut(keyCode: 55, flags: .maskCommand),
+            output: KeyboardShortcut(keyCode: 102),
+            enable: true
+        )
+
+        let dictionary = mapping.toDictionary()
+        let restored = KeyMapping(dictionary: dictionary)
+
+        XCTAssertNotNil(restored)
+        XCTAssertEqual(restored?.input.keyCode, 55)
+        XCTAssertEqual(restored?.input.flags.rawValue, CGEventFlags.maskCommand.rawValue)
+        XCTAssertEqual(restored?.output.keyCode, 102)
+        XCTAssertEqual(restored?.enable, true)
+    }
+
+    func testInitFailsOnMalformedDictionary() {
+        XCTAssertNil(KeyMapping(dictionary: [:]))
+        XCTAssertNil(KeyMapping(dictionary: ["input": ["keyCode": 1, "flags": 0]]))  // missing output
+        XCTAssertNil(KeyMapping(dictionary: [
+            "input": "not a dictionary",
+            "output": ["keyCode": 1, "flags": 0],
+            "enable": true
+        ]))
+    }
+}

--- a/apps/cmd-ime-swift/Tests/CmdIMESwiftTests/KeyboardShortcutTests.swift
+++ b/apps/cmd-ime-swift/Tests/CmdIMESwiftTests/KeyboardShortcutTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import CmdIMESwift
+
+final class KeyboardShortcutTests: XCTestCase {
+
+    func testDictionaryRoundTrip() {
+        let original = KeyboardShortcut(keyCode: 12, flags: [.maskCommand, .maskShift])
+        let restored = KeyboardShortcut(dictionary: original.toDictionary())
+        XCTAssertNotNil(restored)
+        XCTAssertEqual(restored?.keyCode, 12)
+        XCTAssertEqual(restored?.flags.rawValue,
+                       (CGEventFlags.maskCommand.rawValue | CGEventFlags.maskShift.rawValue))
+    }
+
+    func testCommandIgnoredOnCommandKeyItself() {
+        // Holding Command_L (55) shouldn't report "Command is down" — that
+        // would make modifier-only mappings impossible to express.
+        let leftCommand = KeyboardShortcut(keyCode: 55, flags: .maskCommand)
+        XCTAssertFalse(leftCommand.isCommandDown())
+
+        let aWithCommand = KeyboardShortcut(keyCode: 0, flags: .maskCommand)
+        XCTAssertTrue(aWithCommand.isCommandDown())
+    }
+
+    func testShiftIgnoredOnShiftKeyItself() {
+        let leftShift = KeyboardShortcut(keyCode: 56, flags: .maskShift)
+        XCTAssertFalse(leftShift.isShiftDown())
+
+        let aWithShift = KeyboardShortcut(keyCode: 0, flags: .maskShift)
+        XCTAssertTrue(aWithShift.isShiftDown())
+    }
+
+    func testIsCoverRequiresAllExpectedModifiers() {
+        // Mapping wants Cmd+Shift+A; pressing only Cmd+A must not match.
+        let expected = KeyboardShortcut(keyCode: 0, flags: [.maskCommand, .maskShift])
+        let pressedCmdOnly = KeyboardShortcut(keyCode: 0, flags: .maskCommand)
+        XCTAssertFalse(pressedCmdOnly.isCover(expected))
+
+        // Pressing Cmd+Shift+A matches Cmd+Shift+A.
+        let pressedBoth = KeyboardShortcut(keyCode: 0, flags: [.maskCommand, .maskShift])
+        XCTAssertTrue(pressedBoth.isCover(expected))
+
+        // Extra modifiers on the actual press are still considered covering.
+        let pressedExtra = KeyboardShortcut(keyCode: 0, flags: [.maskCommand, .maskShift, .maskAlternate])
+        XCTAssertTrue(pressedExtra.isCover(expected))
+    }
+
+    func testToStringRendersCommonKeys() {
+        XCTAssertEqual(KeyboardShortcut(keyCode: 102).toString(), "英数")
+        XCTAssertEqual(KeyboardShortcut(keyCode: 104).toString(), "かな")
+        XCTAssertEqual(KeyboardShortcut(keyCode: 0, flags: .maskCommand).toString(), "⌘A")
+        XCTAssertEqual(KeyboardShortcut(keyCode: 0, flags: [.maskCommand, .maskShift]).toString(), "⌘⇧A")
+    }
+}


### PR DESCRIPTION
## Summary

Adds 13 new tests on top of the existing 4 KeyEvent tests (17 total, all passing). Each `AppSettingsTests` case uses a fresh `UserDefaults(suiteName:)` so test order is irrelevant and the standard domain stays untouched.

### KeyboardShortcutTests (5)
- Dictionary round-trip preserves keyCode + flags.
- Holding the modifier key itself (e.g. Cmd_L alone) does NOT report "command is down" — this invariant is what makes modifier-only mappings actually match on key release.
- `isCover` requires every expected modifier but allows extras.
- `toString` renders 英数, かな, ⌘A, ⌘⇧A.

### KeyMappingTests (2)
- Dictionary round-trip.
- `init?(dictionary:)` rejects malformed payloads.

### AppSettingsTests (6)
- `lunchAtStartup` → `launchAtStartup` migration removes the legacy key.
- `checkUpdateAtlaunch` → `checkUpdateAtLaunch` migration.
- Default mappings are Cmd_L→英数 / Cmd_R→かな when nothing is stored.
- `addKeyMapping` persists to UserDefaults and updates the global `keyMappingList` that KeyEvent reads.
- `removeKeyMapping` persists removal.
- Exclusion add/remove propagates to `exclusionAppsList` + `exclusionAppsDict`, with idempotent add.

## Closes
- #12

## Stack
Stacked on #20 (which is on #17). Merge order: #17 → #20 → this PR.

## Test plan
- [x] `swift test` — 17/17 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)