### PR TITLE
fix(release): make Homebrew cask handle in-place upgrades cleanly

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,11 +187,30 @@ jobs:
               system_command "/usr/bin/xattr",
                              args: ["-cr", "#{appdir}/CmdIME.app"],
                              sudo: false
+              # Refresh LaunchServices so the new bundle's icon and display
+              # name are picked up immediately (otherwise Finder / System
+              # Settings can show a stale entry).
+              lsregister = "/System/Library/Frameworks/CoreServices.framework/" \\
+                           "Frameworks/LaunchServices.framework/Support/lsregister"
+              system_command lsregister,
+                             args: ["-f", "#{appdir}/CmdIME.app"],
+                             sudo: false
+              # Auto-launch the new build so the user doesn't have to fish
+              # for it after every upgrade.
+              system_command "/usr/bin/open",
+                             args: ["#{appdir}/CmdIME.app"],
+                             sudo: false
             end
 
+            # Gracefully quit the running menu bar agent before brew replaces
+            # the .app, otherwise the old process keeps running on the freed
+            # binary and macOS will not pick up the new build's Accessibility
+            # entry until the user manually restarts.
+            uninstall quit: "com.kazuki.cmdime"
+
             zap trash: [
-              "~/Library/Preferences/com.kazuki.cmd-ime.plist",
               "~/Library/Application Support/cmd-ime",
+              "~/Library/Preferences/com.kazuki.cmdime.plist",
             ]
           end
           EOF


### PR DESCRIPTION
## Summary

The previous cask template forced manual cleanup after every `brew upgrade --cask cmd-ime`:

| Issue | Fix |
|---|---|
| Old menu-bar agent kept running on the freed binary | `uninstall quit: "com.kazuki.cmdime"` |
| Finder / System Settings showed stale icon / display name | `lsregister -f` in postflight |
| User had to manually launch the new build | `open "$appdir/CmdIME.app"` in postflight |
| `zap trash:` plist path used wrong bundle id (`com.kazuki.cmd-ime`) | Fixed to `com.kazuki.cmdime` |

After this lands, the next release's cask will be self-healing for upgrades. The first user-visible improvement appears on the **second** upgrade after this PR (because the old cask is what brew uses to *uninstall* the current install, and only the new cask covers reinstall).

## Closes
- #6 (upgrade flow half — manual quit / launch / icon refresh)

## Still open
- #23 — Accessibility permission still has to be re-granted after each release because ad-hoc signing changes `cdhash`. Real fix needs Developer ID + notarization. The `uninstall quit:` directive does NOT solve that; it just stops the user having to chase a zombie process.

## Notes
- `release.yml` carries a `DO NOT EDIT — change manifest.toml instead` header. This PR edits it directly because the generator template is out of repo. The same change should be ported into the airis-monorepo template.
- Linted with `brew style` against a simulated heredoc expansion — no offenses.

## Test plan
- [x] `brew style` clean on the produced cask body.
- [x] `bash` heredoc expansion verified — Ruby line continuation (`\`) renders correctly in the generated file.
- [ ] After merge, a new release is cut. Run `brew upgrade --cask cmd-ime` from this version → next version. Verify:
  - [ ] Old CmdIME process exits during upgrade.
  - [ ] Finder shows the new build with correct icon (no stale "weird name" entry).
  - [ ] New build launches automatically.
- [ ] Once the user's Apple Developer Program is active, ship #23 to also kill the Accessibility re-grant step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)