### PR TITLE
fix(release): use stable signing identity to preserve TCC grants

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,20 +71,95 @@ jobs:
             echo "✅ Will create release v${{steps.version.outputs.version}}"
           fi
 
+      # A self-signed code-signing certificate gives the bundle a stable
+      # Designated Requirement (anchored to the cert SHA-1 + bundle id),
+      # which is what macOS TCC uses to remember Accessibility grants
+      # across `brew upgrade --cask cmd-ime`. Without this, ad-hoc signing
+      # produces a per-cdhash DR and the user has to re-grant Accessibility
+      # on every release. See Issue #23.
+      #
+      # The step is gated on the secret being present so a release does not
+      # fail before the cert has been minted and uploaded to org secrets;
+      # `package.sh` falls back to ad-hoc when CMDIME_SIGNING_IDENTITY is
+      # empty. Once the cert is in place the Verify step below upgrades
+      # silent ad-hoc fallback to a hard failure.
+      - name: Check signing secret availability
+        if: steps.check_tag.outputs.exists == 'false'
+        id: signing
+        env:
+          CERT_P12_BASE64: ${{ secrets.CMDIME_SIGNING_CERT_P12_BASE64 }}
+        run: |
+          if [ -n "$CERT_P12_BASE64" ]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::warning::CMDIME_SIGNING_CERT_P12_BASE64 is not set; release will fall back to ad-hoc signing (TCC grants will reset on upgrade)"
+          fi
+
+      - name: Import code-signing certificate
+        if: steps.check_tag.outputs.exists == 'false' && steps.signing.outputs.available == 'true'
+        env:
+          CERT_P12_BASE64: ${{ secrets.CMDIME_SIGNING_CERT_P12_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.CMDIME_SIGNING_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/cmdime-signing.keychain-db"
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          CERT_PATH="$RUNNER_TEMP/cmdime-signing.p12"
+
+          echo "$CERT_P12_BASE64" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security import "$CERT_PATH" \
+            -k "$KEYCHAIN_PATH" \
+            -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign
+
+          # Allow codesign to use the imported key without a UI prompt
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Prepend our keychain to the user search list so codesign -s "<name>" resolves it
+          EXISTING_KEYCHAINS=$(security list-keychains -d user | tr -d '"')
+          security list-keychains -d user -s "$KEYCHAIN_PATH" $EXISTING_KEYCHAINS
+
+          rm -f "$CERT_PATH"
+
       - name: Build macOS app
         if: steps.check_tag.outputs.exists == 'false'
+        env:
+          CMD_IME_VERSION: ${{ steps.version.outputs.version }}
+          CMDIME_SIGNING_IDENTITY: ${{ vars.CMDIME_SIGNING_IDENTITY }}
         run: |
           cd apps/cmd-ime-swift
 
-          # Set version from workflow
-          export CMD_IME_VERSION=${{steps.version.outputs.version}}
-
-          # Build using existing script
+          # Build using existing script (reads CMDIME_SIGNING_IDENTITY)
           bash scripts/package.sh
 
           # Copy to release directory
           mkdir -p ../../release
           cp -R .build/release/CmdIME.app ../../release/
+
+      - name: Verify code signature
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          set -euo pipefail
+          codesign -dvv release/CmdIME.app 2>&1 | tee /tmp/codesign.log
+
+          if [ "${{ steps.signing.outputs.available }}" = "true" ]; then
+            # Cert is configured: ad-hoc fallback would silently regress TCC stability
+            if grep -q "Signature=adhoc" /tmp/codesign.log; then
+              echo "ERROR: bundle ended up ad-hoc signed despite cert being configured (identity import failed)" >&2
+              exit 1
+            fi
+            echo "OK: signed with stable identity"
+          else
+            echo "::warning::bundle is ad-hoc signed; expected because CMDIME_SIGNING_CERT_P12_BASE64 is not set"
+          fi
 
       - name: Create DMG
         if: steps.check_tag.outputs.exists == 'false'

--- a/apps/cmd-ime-swift/scripts/package.sh
+++ b/apps/cmd-ime-swift/scripts/package.sh
@@ -93,7 +93,14 @@ cat >> "$INFO_PLIST" <<'EOF'
 </plist>
 EOF
 
-echo ">> Signing app bundle"
-codesign --force --deep --sign - "$APP_DIR"
+# Stable Designated Requirement keeps TCC/Accessibility grants alive across
+# brew upgrades. Set CMDIME_SIGNING_IDENTITY to a self-signed (or Developer ID)
+# identity in CI; falls back to ad-hoc for local dev when unset.
+SIGN_IDENTITY="${CMDIME_SIGNING_IDENTITY:--}"
+echo ">> Signing app bundle with identity: $SIGN_IDENTITY"
+codesign --force --deep \
+    --options runtime \
+    --sign "$SIGN_IDENTITY" \
+    "$APP_DIR"
 
 echo ">> Bundle ready: $APP_DIR"


### PR DESCRIPTION
## Summary
- ad-hoc `codesign -s -` を env 経由の identity に切り替え。CI では self-signed P12 を一時 keychain にインポートして使う。
- `brew upgrade --cask cmd-ime` のたびに Accessibility 権限が消える Issue #23 の根本原因 (per-cdhash な Designated Requirement) を解決する。
- secret 未投入時は ad-hoc fallback + warning で release を継続するので、cert 投入前にこの PR をマージしても CI は止まらない。secret 投入後は verify ステップが silent ad-hoc fallback を hard fail にする。

## Why $0 instead of Apple Developer Program ($99/yr)
Apple TN2206 / TN3127 によれば、自己署名証明書でも DR は cert SHA-1 + bundle id に anchor され安定する。$99/年が買うのは Gatekeeper 受理 + Notarization であって TCC 継続性ではない。Homebrew cask は postflight で `xattr -cr` 済みなので quarantine は剥がれ、Notarization 不在の影響は **Releases ページから DMG を直接ダウンロードしたユーザーが初回 right-click → Open する必要がある** だけに限定される (Homebrew 経由ユーザーは影響なし)。

## Required follow-up (manual)
この PR を merge した時点では release は ad-hoc fallback で継続する。次のリリースから self-signed に切り替えるには:

1. Keychain Access → Certificate Assistant → Create a Certificate
   - Name: `CmdIME Self-Signed Publisher`
   - Identity Type: `Self Signed Root` / Certificate Type: `Code Signing`
2. login keychain で private key を export → `cmd-ime-signing.p12`
3. `base64 -i cmd-ime-signing.p12 | pbcopy`
4. Org credentials (visibility: `selected` → `agiletec-inc/cmd-ime` only) に登録:
   - secret `CMDIME_SIGNING_CERT_P12_BASE64`
   - secret `CMDIME_SIGNING_CERT_PASSWORD`
   - variable `CMDIME_SIGNING_IDENTITY` = `CmdIME Self-Signed Publisher`
5. local の `cmd-ime-signing.p12` を削除

## Test plan
- [x] Local: `unset CMDIME_SIGNING_IDENTITY; bash scripts/package.sh` → ad-hoc fallback で build 成功、`Signature=adhoc` を `codesign -dvv` で確認
- [x] Local: `swift test` 17 件 pass
- [x] `release.yml` の YAML 構文 valid
- [ ] Cert 投入後の最初のリリースで `codesign -dvv /Applications/CmdIME.app` に `Authority=CmdIME Self-Signed Publisher` が出ること
- [ ] Cert 投入後、`brew upgrade --cask cmd-ime` を 2 回連続で実施しても Accessibility 権限が消えないこと (Issue #23 の真の検証 — 1 回目は新署名適用の確認、2 回目は DR 安定の確認)

Refs #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)