### PR TITLE
docs: log TCC stability fix in changelog [Unreleased]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ on the `main` branch via `.github/workflows/release.yml`.
 
 ## [Unreleased]
 
+### Fixed
+- Release builds are now signed with a stable Apple Development identity
+  imported from org-level secrets at CI time, instead of ad-hoc
+  `codesign --sign -`. The bundle's Designated Requirement now anchors
+  to the cert (and bundle id) rather than to a per-build cdhash, so
+  macOS TCC keeps the Accessibility grant across `brew upgrade --cask
+  cmd-ime`. Refs #23.
+
 ## [1.3.4] - 2026-05-02
 
 ### Fixed


### PR DESCRIPTION
## Summary
- CHANGELOG の [Unreleased] セクションに Issue #23 (TCC reset on every brew upgrade) の修正を記録。
- Org credentials (`CMDIME_SIGNING_CERT_P12_BASE64` / `CMDIME_SIGNING_CERT_PASSWORD` / `CMDIME_SIGNING_IDENTITY`) は既に投入済み。
- この PR を merge すると release.yml が走り、初めて Apple Development cert で署名された build が出る → 検証可能。

## Verification (after merge)
1. `release.yml` の `Verify code signature` ステップで `Signature=adhoc` が出ないこと (cert あり時は hard fail にする実装済)。
2. 公開された v1.3.x の DMG をローカルにインストールして `codesign -dvv /Applications/CmdIME.app`:
   - `Authority=Apple Development: valuedata@gmail.com (5H5RL4W864)`
   - `TeamIdentifier=5H5RL4W864`
   - `Signature=adhoc` が消えていること
3. `brew upgrade --cask cmd-ime` を 2 回連続でかけて Accessibility 権限が継続すること (Issue #23 の本検証)。

## Note
画像の cert は 2026-05-16 失効 (約 2 週間)。検証完了後、Xcode で新 cert を再発行 → 同 P12 export → org secret 上書きすれば 1 年延長できる。

Refs #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)