### PR TITLE
fix: align versioning and local packaging

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: ⌘IME version
       description: Click the menu bar ⌘ icon → "About ⌘IME …" — the version is in the title.
-      placeholder: e.g. 1.2.5
+      placeholder: e.g. 2.0.0
     validations:
       required: true
 
@@ -40,7 +40,7 @@ body:
     attributes:
       label: Steps to reproduce
       placeholder: |
-        1. Install ⌘IME 1.2.5 from the latest .dmg
+        1. Install ⌘IME 2.0.0 from the latest .dmg
         2. Launch and grant Accessibility permission
         3. Press left Command — nothing happens
     validations:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,42 +23,14 @@ jobs:
       - name: Determine version bump
         id: version
         run: |
-          # Get highest version tag (sort semantically)
-          LATEST_TAG=$(git tag -l 'v*' | sort -t. -k1,1n -k2,2n -k3,3n | tail -1)
-          if [ -z "$LATEST_TAG" ]; then
-            LATEST_TAG="v1.0.0"
-          fi
-          CURRENT_VERSION=${LATEST_TAG#v}
-
-          echo "📦 Current version: $CURRENT_VERSION (from $LATEST_TAG)"
-
-          # Parse semver
-          IFS='.' read -r major minor patch <<< "$CURRENT_VERSION"
-
-          # Get commit messages since last tag
-          COMMITS=$(git log ${LATEST_TAG}..HEAD --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
-
-          # Determine bump type based on conventional commits
-          BUMP_TYPE="patch"
-
-          if echo "$COMMITS" | grep -qE '^(feat!:|fix!:|BREAKING CHANGE:)'; then
-            BUMP_TYPE="major"
-          elif echo "$COMMITS" | grep -qE '^feat(\(.+\))?:'; then
-            BUMP_TYPE="minor"
+          VERSION=$(awk -F'"' '/^version[[:space:]]*=/ {print $2; exit}' manifest.toml)
+          if [ -z "$VERSION" ]; then
+            echo "Failed to read version from manifest.toml" >&2
+            exit 1
           fi
 
-          # Calculate new version
-          if [ "$BUMP_TYPE" = "major" ]; then
-            NEW_VERSION="$((major + 1)).0.0"
-          elif [ "$BUMP_TYPE" = "minor" ]; then
-            NEW_VERSION="${major}.$((minor + 1)).0"
-          else
-            NEW_VERSION="${major}.${minor}.$((patch + 1))"
-          fi
-
-          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
-          echo "🚀 Bumping $CURRENT_VERSION → $NEW_VERSION ($BUMP_TYPE)"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "📦 Release version from manifest.toml: $VERSION"
 
       - name: Check if already released
         id: check_tag
@@ -134,6 +106,7 @@ jobs:
         env:
           CMD_IME_VERSION: ${{ steps.version.outputs.version }}
           CMDIME_SIGNING_IDENTITY: ${{ vars.CMDIME_SIGNING_IDENTITY }}
+          CMDIME_SPARKLE_PUBLIC_ED_KEY: ${{ vars.CMDIME_SPARKLE_PUBLIC_ED_KEY || secrets.CMDIME_SPARKLE_PUBLIC_ED_KEY }}
         run: |
           cd apps/cmd-ime-swift
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ on the `main` branch via `.github/workflows/release.yml`.
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-05-04
+
+### Changed
+- Major version bump to 2.0.1 to resolve versioning inconsistencies.
+
+
 ### Added
 - `apps/cmd-ime-swift/scripts/generate-self-signed-cert.sh` — helper script to generate
   a self-signed code-signing certificate for stable TCC grants without an Apple
@@ -113,7 +119,8 @@ on the `main` branch via `.github/workflows/release.yml`.
 - Renamed the app from `⌘英かな` to `⌘IME`.
 - Cleaned up repository structure.
 
-[Unreleased]: https://github.com/agiletec-inc/cmd-ime/compare/v1.3.4...HEAD
+[Unreleased]: https://github.com/agiletec-inc/cmd-ime/compare/v2.0.1...HEAD
+[2.0.1]: https://github.com/agiletec-inc/cmd-ime/releases/tag/v2.0.1
 [1.3.4]: https://github.com/agiletec-inc/cmd-ime/releases/tag/v1.3.4
 [1.3.3]: https://github.com/agiletec-inc/cmd-ime/releases/tag/v1.3.3
 [1.3.2]: https://github.com/agiletec-inc/cmd-ime/releases/tag/v1.3.2

--- a/README.md
+++ b/README.md
@@ -59,8 +59,13 @@ cd apps/cmd-ime-swift
 swift build -c release
 
 # Or build a signed .app bundle ready to drag into /Applications
+export CMDIME_SIGNING_IDENTITY="Developer ID Application: <Team Name> (<Team ID>)"
 ./scripts/package.sh
 ```
+
+`package.sh` looks up the Sparkle public key from your login keychain via
+Sparkle's `generate_keys` tool by default. Override with
+`CMDIME_SPARKLE_PUBLIC_ED_KEY` only if you need to inject a specific key.
 
 ## Development
 

--- a/apps/cmd-ime-swift/Package.swift
+++ b/apps/cmd-ime-swift/Package.swift
@@ -10,11 +10,15 @@ let package = Package(
     products: [
         .executable(name: "CmdIMESwift", targets: ["CmdIMESwift"])
     ],
-    dependencies: [],
+    dependencies: [
+        .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.0.0")
+    ],
     targets: [
         .executableTarget(
             name: "CmdIMESwift",
-            dependencies: [],
+            dependencies: [
+                .product(name: "Sparkle", package: "Sparkle")
+            ],
             path: "Sources/CmdIMESwift"
         ),
         .testTarget(

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/CmdIMEApp.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/CmdIMEApp.swift
@@ -1,4 +1,5 @@
 import Cocoa
+import Sparkle
 
 var statusItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength))
 
@@ -6,9 +7,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var windowController: NSWindowController?
     var preferenceWindowController: PreferenceWindowController!
     let keyEvent = KeyEvent()
-    private let bundleWatcher = BundleWatcher()
+    private var updaterController: SPUStandardUpdaterController!
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
+        // Sparkle setup
+        updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+
         // Load preferences and apply them to the legacy globals KeyEvent reads.
         let settings = AppSettings.shared
         settings.bootstrap()
@@ -30,26 +34,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             keyEquivalent: ","
         )
         menu.addItem(NSMenuItem.separator())
+        let updateItem = NSMenuItem(
+            title: "Check for Updates...",
+            action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+            keyEquivalent: ""
+        )
+        updateItem.target = updaterController
+        menu.addItem(updateItem)
+        menu.addItem(NSMenuItem.separator())
         menu.addItem(withTitle: "Restart", action: #selector(AppDelegate.restart(_:)), keyEquivalent: "")
         menu.addItem(withTitle: "Quit", action: #selector(AppDelegate.quit(_:)), keyEquivalent: "q")
 
         keyEvent.start()
-
-        if settings.checkUpdateAtLaunch {
-            checkUpdate()
-        }
-
-        // brew upgrade mv-replaces /Applications/CmdIME.app while we're running.
-        // macOS leaves us alive on the old Mach-O image with a cached Info.plist,
-        // which makes "Check Now" report a stale version. Restart on replace.
-        bundleWatcher.start { [weak self] in
-            guard let self else { return }
-            self.restart(self)
-        }
-    }
-
-    func applicationWillTerminate(_ notification: Notification) {
-        bundleWatcher.stop()
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {

--- a/apps/cmd-ime-swift/scripts/install-local.sh
+++ b/apps/cmd-ime-swift/scripts/install-local.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_BUNDLE="$SCRIPT_DIR/../.build/release/CmdIME.app"
+DEST_APP="/Applications/CmdIME.app"
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+    echo "Error: Build the app first (run package.sh)" >&2
+    exit 1
+fi
+
+echo ">> Preparing to install to $DEST_APP"
+
+# 1. Kill the running app if any
+if pgrep -x "CmdIME" > /dev/null; then
+    echo ">> Closing running instance..."
+    pkill -x "CmdIME" || true
+    sleep 1
+fi
+
+# 2. Backup or Remove existing
+if [[ -d "$DEST_APP" ]]; then
+    echo ">> Removing existing app at $DEST_APP"
+    # Use sudo if permission is needed, but for local dev /Applications is usually writable
+    rm -rf "$DEST_APP"
+fi
+
+# 3. Copy new bundle
+echo ">> Copying new bundle to /Applications"
+cp -R "$APP_BUNDLE" "$DEST_APP"
+
+# 4. Launch the new version
+echo ">> Launching $DEST_APP"
+open "$DEST_APP"
+
+echo ">> Done. Check the version in the menu bar."

--- a/apps/cmd-ime-swift/scripts/package.sh
+++ b/apps/cmd-ime-swift/scripts/package.sh
@@ -10,8 +10,16 @@ APP_NAME="CmdIME"
 APP_DIR="$BUILD_DIR/release/${APP_NAME}.app"
 MACOS_DIR="$APP_DIR/Contents/MacOS"
 RESOURCES_DIR="$APP_DIR/Contents/Resources"
+FRAMEWORKS_DIR="$APP_DIR/Contents/Frameworks"
 INFO_PLIST="$APP_DIR/Contents/Info.plist"
 ICON_SOURCE="$PROJECT_ROOT/../../AppIcon.icns"
+CACHE_DIR="$BUILD_DIR/local-cache"
+CLANG_MODULE_CACHE_DIR="$CACHE_DIR/clang-module-cache"
+SWIFTPM_CACHE_DIR="$CACHE_DIR/swiftpm"
+BUILD_MODE="${CMDIME_BUILD_MODE:-distribution}"
+SPARKLE_KEY_ACCOUNT="${CMDIME_SPARKLE_KEY_ACCOUNT:-agiletec-inc-cmd-ime}"
+SPARKLE_GENERATE_KEYS_BIN="$BUILD_DIR/artifacts/sparkle/Sparkle/bin/generate_keys"
+SPARKLE_PUBLIC_ED_KEY="${CMDIME_SPARKLE_PUBLIC_ED_KEY:-}"
 
 resolve_version() {
     if [[ -n "${CMD_IME_VERSION:-}" ]]; then
@@ -29,9 +37,113 @@ resolve_version() {
     fi
     git -C "$PROJECT_ROOT" describe --tags --always 2>/dev/null || printf '0.0.0'
 }
-VERSION="$(resolve_version)"
 
-echo ">> Building Swift release binary"
+resolve_signing_identity() {
+    if [[ -n "${CMDIME_SIGNING_IDENTITY:-}" ]]; then
+        printf '%s' "$CMDIME_SIGNING_IDENTITY"
+        return
+    fi
+
+    if [[ "$BUILD_MODE" == "local" ]]; then
+        local local_identity
+        local_identity=$(
+            security find-identity -v -p codesigning 2>/dev/null |
+            awk -F'"' '/"Apple Development: / { print $2; exit }'
+        )
+        if [[ -n "$local_identity" ]]; then
+            printf '%s' "$local_identity"
+            return
+        fi
+    fi
+
+    local preferred_identity
+    preferred_identity=$(
+        security find-identity -v -p codesigning 2>/dev/null |
+        awk -F'"' '/"Developer ID Application: / { print $2; exit }'
+    )
+    if [[ -n "$preferred_identity" ]]; then
+        printf '%s' "$preferred_identity"
+        return
+    fi
+
+    printf '%s' "-"
+}
+
+require_distribution_prerequisites() {
+    if [[ "$BUILD_MODE" == "local" ]]; then
+        if [[ "$SIGN_IDENTITY" == "-" ]]; then
+            echo "No Apple Development identity found. Falling back to ad-hoc signing for local build."
+        fi
+        return
+    fi
+
+    if [[ -z "$SPARKLE_PUBLIC_ED_KEY" ]]; then
+        echo "CMDIME_SPARKLE_PUBLIC_ED_KEY is required for Sparkle distribution builds." >&2
+        exit 1
+    fi
+
+    if [[ "$SIGN_IDENTITY" == "-" ]]; then
+        echo "A Developer ID Application signing identity is required for distribution builds." >&2
+        echo "Set CMDIME_SIGNING_IDENTITY explicitly or install a Developer ID Application certificate." >&2
+        exit 1
+    fi
+
+    if [[ "$SIGN_IDENTITY" != Developer\ ID\ Application:* ]]; then
+        echo "Distribution builds must use a Developer ID Application identity." >&2
+        echo "Current identity: $SIGN_IDENTITY" >&2
+        exit 1
+    fi
+}
+
+resolve_sparkle_public_key() {
+    if [[ -n "${CMDIME_SPARKLE_PUBLIC_ED_KEY:-}" ]]; then
+        printf '%s' "$CMDIME_SPARKLE_PUBLIC_ED_KEY"
+        return
+    fi
+
+    if [[ -x "$SPARKLE_GENERATE_KEYS_BIN" ]]; then
+        local detected_public_key
+        detected_public_key=$("$SPARKLE_GENERATE_KEYS_BIN" --account "$SPARKLE_KEY_ACCOUNT" -p 2>/dev/null | awk 'NF {print $NF; exit}')
+        if [[ -n "$detected_public_key" ]]; then
+            printf '%s' "$detected_public_key"
+            return
+        fi
+    fi
+
+    printf '%s' ""
+}
+
+sign_bundle_with_runtime() {
+    local path="$1"
+    shift
+    if [[ "$BUILD_MODE" == "local" ]]; then
+        codesign --force --sign "$SIGN_IDENTITY" "$@" "$path"
+    else
+        codesign --force --timestamp --options runtime --sign "$SIGN_IDENTITY" "$@" "$path"
+    fi
+}
+
+sign_nested_code() {
+    local path="$1"
+    shift
+    if [[ "$BUILD_MODE" == "local" ]]; then
+        codesign --force --sign "$SIGN_IDENTITY" "$@" "$path"
+    else
+        codesign --force --timestamp --sign "$SIGN_IDENTITY" "$@" "$path"
+    fi
+}
+
+VERSION="$(resolve_version)"
+BUILD_NUMBER=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "1")
+SIGN_IDENTITY="$(resolve_signing_identity)"
+SPARKLE_PUBLIC_ED_KEY="$(resolve_sparkle_public_key)"
+
+require_distribution_prerequisites
+
+echo ">> Building Swift release binary (Version: $VERSION, Build: $BUILD_NUMBER)"
+mkdir -p "$CLANG_MODULE_CACHE_DIR" "$SWIFTPM_CACHE_DIR"
+export CLANG_MODULE_CACHE_PATH="$CLANG_MODULE_CACHE_DIR"
+export SWIFTPM_CUSTOM_CACHE_PATH="$SWIFTPM_CACHE_DIR"
 swift build -c release --package-path "$PROJECT_ROOT"
 
 BIN_PATH="$BUILD_DIR/$TRIPLE/release/$BIN_NAME"
@@ -42,13 +154,22 @@ fi
 
 echo ">> Creating app bundle at $APP_DIR"
 rm -rf "$APP_DIR"
-mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR" "$FRAMEWORKS_DIR"
 
-cp "$BIN_PATH" "$MACOS_DIR/$APP_NAME"
+ditto "$BIN_PATH" "$MACOS_DIR/$APP_NAME"
 chmod +x "$MACOS_DIR/$APP_NAME"
+if ! otool -l "$MACOS_DIR/$APP_NAME" | grep -Fq "@executable_path/../Frameworks"; then
+    install_name_tool -add_rpath "@executable_path/../Frameworks" "$MACOS_DIR/$APP_NAME"
+fi
+
+SPARKLE_FRAMEWORK="$BUILD_DIR/$TRIPLE/release/Sparkle.framework"
+if [[ -d "$SPARKLE_FRAMEWORK" ]]; then
+    echo ">> Copying Sparkle.framework"
+    ditto "$SPARKLE_FRAMEWORK" "$FRAMEWORKS_DIR/Sparkle.framework"
+fi
 
 if [[ -f "$ICON_SOURCE" ]]; then
-    cp "$ICON_SOURCE" "$RESOURCES_DIR/AppIcon.icns"
+    ditto "$ICON_SOURCE" "$RESOURCES_DIR/AppIcon.icns"
     ICON_NAME="AppIcon.icns"
 else
     ICON_NAME=""
@@ -70,7 +191,7 @@ cat > "$INFO_PLIST" <<EOF
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleVersion</key>
-    <string>$VERSION</string>
+    <string>$BUILD_NUMBER</string>
     <key>CFBundleShortVersionString</key>
     <string>$VERSION</string>
     <key>LSMinimumSystemVersion</key>
@@ -79,6 +200,10 @@ cat > "$INFO_PLIST" <<EOF
     <true/>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>SUFeedURL</key>
+    <string>https://raw.githubusercontent.com/agiletec-inc/cmd-ime/main/appcast.xml</string>
+    <key>SUPublicEDKey</key>
+    <string>$SPARKLE_PUBLIC_ED_KEY</string>
 EOF
 
 if [[ -n "$ICON_NAME" ]]; then
@@ -93,15 +218,34 @@ cat >> "$INFO_PLIST" <<'EOF'
 </plist>
 EOF
 
-# Stable Designated Requirement keeps TCC/Accessibility grants alive across
-# brew upgrades. Set CMDIME_SIGNING_IDENTITY to a self-signed (or Developer ID)
-# identity in CI; falls back to ad-hoc for local dev when unset.
-SIGN_IDENTITY="${CMDIME_SIGNING_IDENTITY:--}"
 echo ">> Signing app bundle with identity: $SIGN_IDENTITY"
-codesign --force --deep \
-    --options runtime \
-    --timestamp \
-    --sign "$SIGN_IDENTITY" \
-    "$APP_DIR"
+
+SPARKLE_APP="$FRAMEWORKS_DIR/Sparkle.framework/Versions/B/Updater.app"
+SPARKLE_DOWNLOADER_XPC="$FRAMEWORKS_DIR/Sparkle.framework/Versions/B/XPCServices/Downloader.xpc"
+SPARKLE_INSTALLER_XPC="$FRAMEWORKS_DIR/Sparkle.framework/Versions/B/XPCServices/Installer.xpc"
+SPARKLE_AUTOUPDATE="$FRAMEWORKS_DIR/Sparkle.framework/Versions/B/Autoupdate"
+SPARKLE_BINARY="$FRAMEWORKS_DIR/Sparkle.framework/Versions/B/Sparkle"
+
+if [[ -d "$SPARKLE_DOWNLOADER_XPC" ]]; then
+    sign_bundle_with_runtime "$SPARKLE_DOWNLOADER_XPC"
+fi
+
+if [[ -d "$SPARKLE_INSTALLER_XPC" ]]; then
+    sign_bundle_with_runtime "$SPARKLE_INSTALLER_XPC"
+fi
+
+if [[ -d "$SPARKLE_APP" ]]; then
+    sign_bundle_with_runtime "$SPARKLE_APP"
+fi
+
+if [[ -f "$SPARKLE_AUTOUPDATE" ]]; then
+    sign_bundle_with_runtime "$SPARKLE_AUTOUPDATE" --identifier "com.kazuki.cmdime.sparkle.autoupdate"
+fi
+
+if [[ -f "$SPARKLE_BINARY" ]]; then
+    sign_nested_code "$FRAMEWORKS_DIR/Sparkle.framework"
+fi
+
+sign_bundle_with_runtime "$APP_DIR"
 
 echo ">> Bundle ready: $APP_DIR"

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 [project]
 id = "cmd-ime"
 name = "⌘IME"
-version = "1.2.5"
+version = "2.0.1"
 description = "Lightweight macOS app for switching between alphanumeric and kana input using Command keys"
 authors = ["Kazuki <kazuki@agiletec.jp>"]
 license = "MIT"


### PR DESCRIPTION
Align the app bundle versioning and release workflow with manifest.toml as the single source of truth, and keep local packaging usable for on-machine verification.\n\nSummary:\n- Read the release version from manifest.toml\n- Make the release workflow tag releases from the manifest version\n- Keep local packaging working with Apple Development signing\n- Preserve distribution-mode requirements for Developer ID + Sparkle public key\n- Update the changelog to the new release version