### PR TITLE
fix(ci): remove secrets context from if condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,21 @@ jobs:
 
           echo "✅ DMG created: cmd-ime-${VERSION}.dmg"
 
+      - name: Check notarization availability
+        if: steps.check_tag.outputs.exists == 'false'
+        id: notarize
+        env:
+          _APPLE_ID: ${{ secrets.APPLE_ID }}
+        run: |
+          if [ -n "$_APPLE_ID" ]; then
+            echo "available=true" >> $GITHUB_OUTPUT
+          else
+            echo "available=false" >> $GITHUB_OUTPUT
+            echo "::warning::APPLE_ID is not set; skipping notarization"
+          fi
+
       - name: Notarize DMG
-        if: steps.check_tag.outputs.exists == 'false' && secrets.APPLE_ID != ''
+        if: steps.check_tag.outputs.exists == 'false' && steps.notarize.outputs.available == 'true'
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}


### PR DESCRIPTION
## Summary

- `if: ... && secrets.APPLE_ID != ''` は GitHub Actions が `if` 条件内の `secrets` 参照をブロックするため、ワークフローが parse 時に 0 秒・0 jobs で落ちていた
- 専用の "Check notarization availability" ステップを追加し、シークレットを env 経由で読んで plain boolean を output する方式に変更

## Root Cause

PR #29 (a29c32a) で追加された Notarize ステップの `if` 条件が原因。2026-05-04 以降の全 CI ラン（#30〜#44 merge）がこれで 0 秒失敗していた。

## Test plan
- [ ] PR が main にマージされた後、次の push で CI が正常に起動することを確認
- [ ] APPLE_ID シークレット未設定の場合、notarization がスキップされること

🤖 Generated with [Claude Code](https://claude.ai/claude-code)