### PR TITLE
ci: add CI and auto-merge workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,18 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'appcast.xml'
+      - '.github/ISSUE_TEMPLATE/**'
+  push:
+    branches: [main]
+    paths-ignore:
+      - '*.md'
+      - 'appcast.xml'
+      - '.github/ISSUE_TEMPLATE/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: macos-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: apps/cmd-ime-swift
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: swift build -c release
+      - name: Test
+        run: swift test


### PR DESCRIPTION
## Summary

- `ci.yml`: PRごとに `swift build -c release` + `swift test` を `macos-latest` で実行
- `auto-merge.yml`: CI通過後に自動マージ（`agile-deploy` / `agile-server` と同一パターン）
- リポジトリ設定: auto-merge 有効化、squash/rebase 無効化（org ルールセットに合わせて merge commit のみ）
- ブランチ保護: `ci` ジョブを required status check に設定

## 動作フロー

```
PR作成
  → auto-merge.yml が --auto --merge を有効化
  → ci.yml が swift build + swift test を実行
  → CI通過 → 自動でマージ
```

## Test plan

- [ ] このPR自身のCI (ci.yml) が通過すること
- [ ] auto-merge が有効化されること
- [ ] CIが通過後に自動マージされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)