### PR TITLE
ci: drop redundant swift build -c release step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,5 @@ jobs:
         working-directory: apps/cmd-ime-swift
     steps:
       - uses: actions/checkout@v4
-      - name: Build
-        run: swift build -c release
       - name: Test
         run: swift test


### PR DESCRIPTION
`swift test` が内部でデバッグビルドを行うため、`swift build -c release` は重複。
リリースビルド自体は `release.yml` の `scripts/package.sh` で行われるため CI では不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)