### PR TITLE
fix: remove redundant reenableTapIfNeeded observer; close #41 #42 #43

### DIFF
--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/KeyEvent.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/KeyEvent.swift
@@ -188,13 +188,6 @@ class KeyEvent: NSObject {
         tapHeartbeat = Timer.scheduledTimer(withTimeInterval: 5.0, repeats: true) { [weak self] _ in
             self?.reenableTapIfNeeded()
         }
-
-        NSWorkspace.shared.notificationCenter.addObserver(
-            self,
-            selector: #selector(reenableTapIfNeeded),
-            name: NSWorkspace.didActivateApplicationNotification,
-            object: nil
-        )
     }
 
     @objc private func reenableTapIfNeeded() {


### PR DESCRIPTION
## Summary

- #41, #42, #43 の修正は `6a96e61` (fix/github-issues-34-43) で完了済みだったが、issueがクローズされていなかった
- 残っていた実際のバグを修正: `setupCGEventTap()` が呼ばれるたびに `reenableTapIfNeeded` の NSWorkspace オブザーバーが重複登録される問題
  - タップ再生成パス (`setupCGEventTap → reenableTapIfNeeded → setupCGEventTap`) を経るたびにオブザーバーが累積していた
  - 5秒ハートビートタイマーが同等の役割を果たしているため、NSWorkspace オブザーバーは不要

## Test plan

- [ ] `swift build` passes
- [ ] `swift test` passes (20 tests, 0 failures)

Closes #41
Closes #42
Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)