### PR TITLE
feat: input key presets + 3-mode switching (Global / Per-app / Smart)

### DIFF
--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/AutoSwitcher.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/AutoSwitcher.swift
@@ -1,3 +1,8 @@
+//
+//  AutoSwitcher.swift
+//  ⌘IME
+//
+
 import Cocoa
 import Carbon.HIToolbox
 
@@ -10,55 +15,51 @@ final class AutoSwitcher {
     private var perAppSource: [String: String] = [:]
     private var currentAppID: String = ""
 
-    // When in a URL field, this holds the source to restore on exit.
-    private var savedBeforeURLField: String?
+    // When in an auto-switch field, this holds the source to restore on exit.
+    private var savedBeforeAutoField: String?
 
     private var pollTimer: Timer?
 
     // Call once on app launch; timer runs forever but is a no-op when disabled.
     func start() {
         pollTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
-            // Timer callbacks aren't @MainActor, but AutoSwitcher is always on main
-            // thread and this timer is scheduled on the main RunLoop.
             MainActor.assumeIsolated { self?.tick() }
         }
     }
 
     // Called by KeyEvent.setActiveApp on every app switch.
     func handleAppActivation(bundleID: String, pid: pid_t) {
-        guard AppSettings.shared.autoSwitching else { return }
+        let mode = AppSettings.shared.switchingMode
+        guard mode == .perApp || mode == .smart else { return }
         guard bundleID != currentAppID else { return }
 
-        // Save current source for the outgoing app.
         if !currentAppID.isEmpty {
             perAppSource[currentAppID] = currentInputSourceID()
         }
 
-        // Restore remembered source for the incoming app.
         if let saved = perAppSource[bundleID] {
             selectInputSource(id: saved)
         }
 
         currentAppID = bundleID
-        savedBeforeURLField = nil
+        savedBeforeAutoField = nil
     }
 
-    // MARK: - URL field polling
+    // MARK: - Field polling (smart mode only)
 
     private func tick() {
-        guard AppSettings.shared.autoSwitching else {
-            // Feature disabled: clear any outstanding URL field state.
-            if savedBeforeURLField != nil { restoreFromURLField() }
+        guard AppSettings.shared.switchingMode == .smart else {
+            if savedBeforeAutoField != nil { restoreFromAutoField() }
             return
         }
-        checkURLField()
+        checkSmartField()
     }
 
-    private func checkURLField() {
+    private func checkSmartField() {
         guard let app = NSWorkspace.shared.frontmostApplication,
               let bundleID = app.bundleIdentifier,
               exclusionAppsDict[bundleID] == nil else {
-            restoreFromURLField()
+            restoreFromAutoField()
             return
         }
 
@@ -67,35 +68,54 @@ final class AutoSwitcher {
         guard AXUIElementCopyAttributeValue(
             appElement, kAXFocusedUIElementAttribute as CFString, &focusedRef
         ) == .success, let focused = focusedRef else {
-            restoreFromURLField()
+            restoreFromAutoField()
             return
         }
 
         // swiftlint:disable:next force_cast
-        if isURLTextField(focused as! AXUIElement) {
-            if savedBeforeURLField == nil {
-                savedBeforeURLField = currentInputSourceID()
+        if isASCIIOnlyField(focused as! AXUIElement) {
+            if savedBeforeAutoField == nil {
+                savedBeforeAutoField = currentInputSourceID()
                 selectASCIICapable()
             }
         } else {
-            restoreFromURLField()
+            restoreFromAutoField()
         }
     }
 
-    private func restoreFromURLField() {
-        guard let saved = savedBeforeURLField else { return }
+    private func restoreFromAutoField() {
+        guard let saved = savedBeforeAutoField else { return }
         selectInputSource(id: saved)
-        savedBeforeURLField = nil
+        savedBeforeAutoField = nil
     }
 
-    // MARK: - URL field detection
+    // MARK: - ASCII-only field detection
 
-    private func isURLTextField(_ element: AXUIElement) -> Bool {
+    private func isASCIIOnlyField(_ element: AXUIElement) -> Bool {
         var roleRef: AnyObject?
         guard AXUIElementCopyAttributeValue(element, kAXRoleAttribute as CFString, &roleRef) == .success,
-              (roleRef as? String) == kAXTextFieldRole else { return false }
+              let role = roleRef as? String else { return false }
 
-        // Check description and identifier for browser URL bar hints.
+        // URL bars in browsers
+        if role == (kAXTextFieldRole as String) && isURLTextField(element) { return true }
+
+        // Only inspect text fields and combo boxes further
+        guard role == (kAXTextFieldRole as String) || role == (kAXComboBoxRole as String) else { return false }
+
+        let asciiHints = ["url", "address", "location", "phone", "tel", "email",
+                          "zip", "postal", "number", "numeric", "code", "pin", "otp"]
+        for attr in [kAXDescriptionAttribute, kAXIdentifierAttribute,
+                     kAXPlaceholderValueAttribute, kAXTitleUIElementAttribute] as [String] {
+            var ref: AnyObject?
+            guard AXUIElementCopyAttributeValue(element, attr as CFString, &ref) == .success,
+                  let str = ref as? String else { continue }
+            let lower = str.lowercased()
+            if asciiHints.contains(where: { lower.contains($0) }) { return true }
+        }
+        return false
+    }
+
+    private func isURLTextField(_ element: AXUIElement) -> Bool {
         for attr in [kAXDescriptionAttribute, kAXIdentifierAttribute] as [String] {
             var ref: AnyObject?
             guard AXUIElementCopyAttributeValue(element, attr as CFString, &ref) == .success,

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/AppSettings.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/AppSettings.swift
@@ -17,6 +17,12 @@ import SwiftUI
 final class AppSettings: ObservableObject {
     static let shared = AppSettings()
 
+    enum SwitchingMode: Int {
+        case global = 0   // no automatic switching
+        case perApp = 1   // remember input source per app
+        case smart = 2    // perApp + context-aware field detection
+    }
+
     enum Keys {
         static let launchAtStartup = "launchAtStartup"
         static let legacyLaunchAtStartup = "lunchAtStartup"
@@ -25,7 +31,8 @@ final class AppSettings: ObservableObject {
         static let legacyCheckUpdateAtLaunch = "checkUpdateAtlaunch"
         static let keyMappings = "mappings"
         static let exclusionApps = "exclusionApps"
-        static let autoSwitching = "autoSwitching"
+        static let switchingMode = "switchingMode"
+        static let legacyAutoSwitching = "autoSwitching"
     }
 
     private let defaults: UserDefaults
@@ -35,7 +42,7 @@ final class AppSettings: ObservableObject {
     @Published var checkUpdateAtLaunch: Bool
     @Published var keyMappings: [KeyMapping]
     @Published var exclusionApps: [AppData]
-    @Published var autoSwitching: Bool
+    @Published var switchingMode: SwitchingMode
 
     private var cancellables: Set<AnyCancellable> = []
     private var isApplyingExternalUpdate = false
@@ -54,7 +61,7 @@ final class AppSettings: ObservableObject {
 
         self.keyMappings = Self.loadKeyMappings(from: defaults)
         self.exclusionApps = Self.loadExclusionApps(from: defaults)
-        self.autoSwitching = (defaults.object(forKey: Keys.autoSwitching) as? Int ?? 0) != 0
+        self.switchingMode = Self.loadSwitchingMode(from: defaults)
 
         publishGlobalsFromState()
         observePropertyChanges()
@@ -160,10 +167,10 @@ final class AppSettings: ObservableObject {
             }
             .store(in: &cancellables)
 
-        $autoSwitching
+        $switchingMode
             .dropFirst()
             .sink { [weak self] newValue in
-                self?.defaults.set(newValue ? 1 : 0, forKey: Keys.autoSwitching)
+                self?.defaults.set(newValue.rawValue, forKey: Keys.switchingMode)
             }
             .store(in: &cancellables)
     }
@@ -186,6 +193,18 @@ final class AppSettings: ObservableObject {
             defaults.set(legacy, forKey: Keys.checkUpdateAtLaunch)
             defaults.removeObject(forKey: Keys.legacyCheckUpdateAtLaunch)
         }
+        // autoSwitching (Bool) → switchingMode (Int): true maps to .smart
+        if defaults.object(forKey: Keys.switchingMode) == nil {
+            let old = (defaults.object(forKey: Keys.legacyAutoSwitching) as? Int ?? 0) != 0
+            defaults.set(old ? SwitchingMode.smart.rawValue : SwitchingMode.global.rawValue,
+                         forKey: Keys.switchingMode)
+            defaults.removeObject(forKey: Keys.legacyAutoSwitching)
+        }
+    }
+
+    private static func loadSwitchingMode(from defaults: UserDefaults) -> SwitchingMode {
+        let raw = defaults.object(forKey: Keys.switchingMode) as? Int ?? SwitchingMode.global.rawValue
+        return SwitchingMode(rawValue: raw) ?? .global
     }
 
     private static func loadKeyMappings(from defaults: UserDefaults) -> [KeyMapping] {

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/GeneralSettingsView.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/GeneralSettingsView.swift
@@ -38,15 +38,25 @@ struct GeneralSettingsView: View {
                 }
             }
 
-            Section {
-                Toggle(isOn: $settings.autoSwitching) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text("Smart input switching")
-                        Text("Restores per-app input source on switch. Auto-switches to alphanumeric in URL bars. (Beta)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+            Section("Input Switching") {
+                Picker("Mode", selection: $settings.switchingMode) {
+                    Text("Off").tag(AppSettings.SwitchingMode.global)
+                    Text("Per app").tag(AppSettings.SwitchingMode.perApp)
+                    Text("Smart").tag(AppSettings.SwitchingMode.smart)
+                }
+                .pickerStyle(.segmented)
+                Group {
+                    switch settings.switchingMode {
+                    case .global:
+                        Text("No automatic switching. Input source stays as-is when you switch apps.")
+                    case .perApp:
+                        Text("Remembers and restores the input source for each app when you switch.")
+                    case .smart:
+                        Text("Per-app memory plus auto-switch to alphanumeric in URL bars, phone, email, and ZIP fields. (Beta)")
                     }
                 }
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
 
             Section("About") {

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/ShortcutsSettingsView.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/ShortcutsSettingsView.swift
@@ -19,9 +19,22 @@ struct ShortcutsSettingsView: View {
         let index: Int
     }
 
+    // Common input keys — includes IME-only keys that can't be recorded on English keyboards.
+    private static let inputPresets: [(label: String, shortcut: KeyboardShortcut)] = [
+        ("Left ⌘  (Left Command)", KeyboardShortcut(keyCode: 55)),
+        ("Right ⌘  (Right Command)", KeyboardShortcut(keyCode: 54)),
+        ("英数  (Eisu / Alphanumeric)", KeyboardShortcut(keyCode: 102)),
+        ("かな  (Kana)", KeyboardShortcut(keyCode: 104)),
+        ("⇪  (Caps Lock)", KeyboardShortcut(keyCode: 57)),
+        ("Left ⇧  (Left Shift)", KeyboardShortcut(keyCode: 56)),
+        ("Right ⇧  (Right Shift)", KeyboardShortcut(keyCode: 60)),
+        ("Left ⌥  (Left Option)", KeyboardShortcut(keyCode: 58)),
+        ("Right ⌥  (Right Option)", KeyboardShortcut(keyCode: 61)),
+        ("Left ⌃  (Left Control)", KeyboardShortcut(keyCode: 59)),
+        ("Right ⌃  (Right Control)", KeyboardShortcut(keyCode: 62)),
+    ]
+
     // Preset output options shown in the dropdown.
-    // IME virtual keys (英数/かな) can't be pressed physically on most keyboards,
-    // so the output field uses a picker instead of a key recorder.
     private static let outputPresets: [(label: String, shortcut: KeyboardShortcut)] = [
         ("英数  (Alphanumeric)", KeyboardShortcut(keyCode: 102)),
         ("かな  (Kana)", KeyboardShortcut(keyCode: 104)),
@@ -30,7 +43,7 @@ struct ShortcutsSettingsView: View {
 
     var body: some View {
         VStack(spacing: 8) {
-            Text("Input: click to record a modifier key (e.g. left ⌘). Output: choose from the preset menu.")
+            Text("Input: choose from the preset menu or record a custom key. Output: choose from the preset menu.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -100,21 +113,35 @@ struct ShortcutsSettingsView: View {
 
     @ViewBuilder
     private func inputCell(label: String, index: Int) -> some View {
-        Button {
-            inputEditing = InputEdit(index: index)
+        Menu {
+            ForEach(Self.inputPresets, id: \.label) { preset in
+                Button {
+                    settings.updateKeyMapping(at: index, input: preset.shortcut)
+                } label: {
+                    if label == preset.shortcut.toString() {
+                        Label(preset.label, systemImage: "checkmark")
+                    } else {
+                        Text(preset.label)
+                    }
+                }
+            }
+            Divider()
+            Button("Record custom key…") {
+                inputEditing = InputEdit(index: index)
+            }
         } label: {
             HStack(spacing: 6) {
                 Text(label.isEmpty ? "Input" : label)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .foregroundStyle(label.isEmpty ? Color.secondary : Color.primary)
-                Image(systemName: "square.and.pencil")
-                    .font(.caption)
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.caption2)
                     .foregroundStyle(.tertiary)
             }
             .cellStyle()
         }
-        .buttonStyle(.plain)
-        .help("Click to record a new input key")
+        .menuStyle(.borderlessButton)
+        .help("Choose an input key")
     }
 
     @ViewBuilder


### PR DESCRIPTION
## Summary

### Shortcuts — Input column is now a preset Menu
英数/かなキーは日本語キーボードにしか物理キーがないため、英語キーボードのユーザーは KeyRecorder でこれらを登録できなかった。Input列をOutputと同じMenuスタイルに変更し、プリセットから選択できるようにした。

- プリセット: Left/Right ⌘, 英数, かな, Caps Lock, Left/Right ⇧/⌥/⌃
- "Record custom key…" からは従来通り KeyRecorderSheet を開ける

### General — 3モード切替 (Input Switching)
`autoSwitching: Bool` を `switchingMode: SwitchingMode` enum に置き換え。

| Mode | 動作 |
|------|------|
| **Off** | 自動切替なし（旧 autoSwitching = false） |
| **Per app** | アプリ切替時に入力ソースを記憶・復元 |
| **Smart** | Per-app + URLバー・電話・メール・ZIP・PINフィールドで英数に自動切替（旧 autoSwitching = true、Beta） |

既存ユーザーは `autoSwitching = true → Smart`、`false → Off` に自動マイグレーション。

### AutoSwitcher — Smart検出範囲を拡張
URL バーに加えて、AXの description/identifier/placeholder 属性に `phone`, `tel`, `email`, `zip`, `postal`, `number`, `pin`, `otp` 等のヒントを含むフィールドでも英数に自動切替。

## Test plan
- [ ] `swift build` passes
- [ ] `swift test` passes (20 tests, 0 failures)
- [ ] Shortcuts画面でInputドロップダウンが開き、英数/かなが選択できる
- [ ] General画面でOff/Per app/Smartの3セグメントが切り替わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)