### PR TITLE
chore: bump version to 2.3.0

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 [project]
 id = "cmd-ime"
 name = "⌘IME"
-version = "2.2.0"
+version = "2.3.0"
 description = "Lightweight macOS app for switching between alphanumeric and kana input using Command keys"
 authors = ["Kazuki <kazuki@agiletec.jp>"]
 license = "MIT"


### PR DESCRIPTION
## Summary

- Shortcuts UI: Key/Actionの2列構成に変更、プリセットのみのメニューに（Recorder削除）
- Input Switching: Off / Per-app / Smart の3モード切替に拡張
- Smart mode: URLバー + phone/email/zipフィールドで英数自動切替
- バグ修正: setupCGEventTap再実行時のNSWorkspaceオブザーバー重複登録を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)