### PR TITLE
chore: bump version to 2.3.2

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 [project]
 id = "cmd-ime"
 name = "⌘IME"
-version = "2.3.1"
+version = "2.3.2"
 description = "Lightweight macOS app for switching between alphanumeric and kana input using Command keys"
 authors = ["Kazuki <kazuki@agiletec.jp>"]
 license = "MIT"


### PR DESCRIPTION
Releases v2.3.2 with:
- Sparkle native update UI (Install and Relaunch, Cmd+W to close)
- `SUFeedURL` → `releases/latest/download/appcast.xml` (branch protection fix)
- SPM build cache in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)