### PR TITLE
fix: trigger release workflow on PR merge (not push)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,16 @@
 name: Release to Homebrew
 
 on:
-  push:
-    branches:
-      - main
+  pull_request:
+    types: [closed]
+    branches: [main]
   workflow_dispatch:
 
 jobs:
   release:
+    # pull_request: run only on actual merges (not closed-without-merge)
+    # workflow_dispatch: always run (manual trigger for re-runs)
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: macos-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Root cause

`GITHUB_TOKEN` で行われたマージ（auto-merge を含む）が main に push しても、GitHub は意図的に下流ワークフローを起動しない仕様。

> "When you use the repository's GITHUB_TOKEN to perform tasks, events triggered by the GITHUB_TOKEN will not create a new workflow run."
> — GitHub Docs: Automatic Token Authentication

## Fix

`on: push: branches: [main]` → `on: pull_request: types: [closed]` + `if: merged == true`

`pull_request: closed` イベントは GITHUB_TOKEN マージでも必ず発火する。`workflow_dispatch` は手動再実行用に残す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)