### PR TITLE
fix: address code audit findings (#60–#77)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,6 @@ on:
       - '*.md'
       - 'appcast.xml'
       - '.github/ISSUE_TEMPLATE/**'
-  push:
-    branches: [main]
-    paths-ignore:
-      - '*.md'
-      - 'appcast.xml'
-      - '.github/ISSUE_TEMPLATE/**'
   workflow_dispatch:
 
 concurrency:
@@ -23,10 +17,19 @@ jobs:
   ci:
     runs-on: macos-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: apps/cmd-ime-swift
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Swift build
+        uses: actions/cache@v4
+        with:
+          path: apps/cmd-ime-swift/.build
+          key: ${{ runner.os }}-spm-${{ hashFiles('apps/cmd-ime-swift/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
       - name: Test
         run: swift test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,7 @@ jobs:
     # workflow_dispatch: always run (manual trigger for re-runs)
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: macos-latest
+    timeout-minutes: 45
     permissions:
       contents: write
     steps:
@@ -145,22 +146,17 @@ jobs:
             echo "::warning::bundle is ad-hoc signed; expected because CMDIME_SIGNING_CERT_P12_BASE64 is not set"
           fi
 
-      - name: Create DMG and ZIP
+      - name: Create DMG
         if: steps.check_tag.outputs.exists == 'false'
         run: |
           VERSION=${{steps.version.outputs.version}}
 
-          # DMG for Homebrew cask (browser download)
           hdiutil create -volname "CmdIME" \
             -srcfolder "release/CmdIME.app" \
             -ov -format UDZO \
             "cmd-ime-${VERSION}.dmg"
 
-          # ZIP for Sparkle in-app "Install and Relaunch"
-          ditto -c -k --keepParent "release/CmdIME.app" "cmd-ime-${VERSION}.zip"
-
           echo "✅ DMG created: cmd-ime-${VERSION}.dmg"
-          echo "✅ ZIP created: cmd-ime-${VERSION}.zip"
 
       - name: Check notarization availability
         if: steps.check_tag.outputs.exists == 'false'
@@ -196,6 +192,16 @@ jobs:
           xcrun stapler staple "$DMG_PATH"
           xcrun stapler staple "release/CmdIME.app"
 
+      - name: Create ZIP
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          VERSION=${{steps.version.outputs.version}}
+
+          # Create ZIP after notarization so stapled ticket is included in the Sparkle distribution
+          ditto -c -k --keepParent "release/CmdIME.app" "cmd-ime-${VERSION}.zip"
+
+          echo "✅ ZIP created: cmd-ime-${VERSION}.zip"
+
       - name: Calculate SHA256
         if: steps.check_tag.outputs.exists == 'false'
         id: sha256
@@ -216,11 +222,21 @@ jobs:
           ZIP_PATH="cmd-ime-${VERSION}.zip"
           SIGN_UPDATE="apps/cmd-ime-swift/.build/artifacts/sparkle/Sparkle/bin/sign_update"
 
+          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
+            echo "::error::CMDIME_SPARKLE_PRIVATE_ED_KEY is not set — in-app updates will be broken"
+            exit 1
+          fi
+
+          trap 'rm -f /tmp/sparkle-ed-key.pem' EXIT
           echo "$SPARKLE_PRIVATE_KEY" > /tmp/sparkle-ed-key.pem
           SIG=$("$SIGN_UPDATE" "$ZIP_PATH" -f /tmp/sparkle-ed-key.pem \
             | grep -o 'sparkle:edSignature="[^"]*"' \
             | cut -d'"' -f2)
-          rm -f /tmp/sparkle-ed-key.pem
+
+          if [ -z "$SIG" ]; then
+            echo "::error::sign_update returned empty signature — check CMDIME_SPARKLE_PRIVATE_ED_KEY"
+            exit 1
+          fi
 
           ZIP_SIZE=$(wc -c < "$ZIP_PATH" | tr -d '[:space:]')
           echo "edSignature=$SIG" >> $GITHUB_OUTPUT
@@ -235,7 +251,7 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           SIG="${{ steps.sparkle.outputs.edSignature }}"
           ZIP_SIZE="${{ steps.sparkle.outputs.zipSize }}"
-          BUILD_NUMBER=$(git rev-parse --short HEAD)
+          BUILD_NUMBER=$(echo "$VERSION" | awk -F. '{printf "%d%02d%02d", $1, $2, $3}')
           PUB_DATE=$(date -u "+%a, %d %b %Y %H:%M:%S +0000")
 
           awk \

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/CmdIMEApp.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/CmdIMEApp.swift
@@ -11,6 +11,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let keyEvent = KeyEvent()
     var updaterController: SPUStandardUpdaterController!
     private var cancellables = Set<AnyCancellable>()
+    private var bundleWatcher: BundleWatcher?
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         AppDelegate.shared = self
@@ -62,6 +63,16 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         MainActor.assumeIsolated { AutoSwitcher.shared.start() }
         keyEvent.start()
+
+        bundleWatcher = BundleWatcher()
+        bundleWatcher?.start {
+            let url = URL(fileURLWithPath: Bundle.main.bundlePath)
+            let task = Process()
+            task.launchPath = "/usr/bin/open"
+            task.arguments = [url.path]
+            do { try task.run() } catch {}
+            NSApplication.shared.terminate(nil)
+        }
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
@@ -78,7 +89,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let task = Process()
         task.launchPath = "/usr/bin/open"
         task.arguments = [url.path]
-        task.launch()
+        do { try task.run() } catch { NSLog("⌘IME: restart failed: %@", error.localizedDescription) }
         NSApplication.shared.terminate(self)
     }
 

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/KeyEvent.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/KeyEvent.swift
@@ -28,6 +28,7 @@ class KeyEvent: NSObject {
     private var tapRetryAttempts = 0
     private var tapObserver: Unmanaged<KeyEvent>?
     private var tapHeartbeat: Timer?
+    private var nsEventMonitors: [Any] = []
 
     override init() {
         super.init()
@@ -36,6 +37,7 @@ class KeyEvent: NSObject {
     deinit {
         tapHeartbeat?.invalidate()
         tapObserver?.release()
+        nsEventMonitors.forEach { NSEvent.removeMonitor($0) }
         NSWorkspace.shared.notificationCenter.removeObserver(self)
     }
 
@@ -107,14 +109,14 @@ class KeyEvent: NSObject {
             .scrollWheel
         ]
 
-        NSEvent.addGlobalMonitorForEvents(matching: nsEventMaskList) {(_: NSEvent) in
-            self.keyCode = nil
-        }
+        if let m = NSEvent.addGlobalMonitorForEvents(matching: nsEventMaskList, handler: { [weak self] _ in
+            self?.keyCode = nil
+        }) { nsEventMonitors.append(m) }
 
-        NSEvent.addLocalMonitorForEvents(matching: nsEventMaskList) {(event: NSEvent) -> NSEvent? in
-            self.keyCode = nil
+        if let m = NSEvent.addLocalMonitorForEvents(matching: nsEventMaskList, handler: { [weak self] event in
+            self?.keyCode = nil
             return event
-        }
+        }) { nsEventMonitors.append(m) }
 
         // CGEvent tap can run on main thread's RunLoop since NSApplication.run() handles it
         setupCGEventTap()
@@ -234,10 +236,10 @@ class KeyEvent: NSObject {
         case CGEventType.flagsChanged:
             let keyCode = CGKeyCode(event.getIntegerValueField(.keyboardEventKeycode))
 
-            if modifierMasks[keyCode] == nil {
+            guard let mask = modifierMasks[keyCode] else {
                 return Unmanaged.passRetained(event)
             }
-            return event.flags.rawValue & modifierMasks[keyCode]!.rawValue != 0 ?
+            return event.flags.rawValue & mask.rawValue != 0 ?
                 modifierKeyDown(event) : modifierKeyUp(event)
 
         case CGEventType.keyDown:
@@ -335,7 +337,7 @@ class KeyEvent: NSObject {
         let lookupKey = keyCode ?? shortcut.keyCode
         guard let mappingList = shortcutList[lookupKey] else { return nil }
 
-        for mapping in mappingList where shortcut.isCover(mapping.input) {
+        for mapping in mappingList where mapping.enable && shortcut.isCover(mapping.input) {
             return mapping
         }
         return nil
@@ -353,12 +355,10 @@ class KeyEvent: NSObject {
             ev.flags = flags
         }
 
-        let shortcut = KeyboardShortcut(ev)
         ev.setIntegerValueField(.keyboardEventKeycode, value: Int64(mapping.output.keyCode))
         ev.flags = CGEventFlags(
             rawValue: (ev.flags.rawValue & ~mapping.input.flags.rawValue) | mapping.output.flags.rawValue
         )
-        _ = shortcut  // suppress unused warning; shortcut was used for isCover check in findMapping
         return .remap(ev)
     }
 }

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/KeyMappings.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/KeyMappings.swift
@@ -11,11 +11,6 @@ import Cocoa
 var keyMappingList: [KeyMapping] = []
 var shortcutList: [CGKeyCode: [KeyMapping]] = [:]
 
-func saveKeyMappings() {
-    UserDefaults.standard.set(keyMappingList.map { $0.toDictionary() },
-                               forKey: AppSettings.Keys.keyMappings)
-}
-
 func keyMappingListToShortcutList() {
     var rebuilt: [CGKeyCode: [KeyMapping]] = [:]
     for mapping in keyMappingList {

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/PreferenceWindowController.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/PreferenceWindowController.swift
@@ -34,6 +34,10 @@ final class PreferenceWindowController: NSWindowController, NSWindowDelegate {
     func showAndActivate(_ sender: AnyObject?) {
         showWindow(sender)
         window?.makeKeyAndOrderFront(sender)
-        NSApp.activate(ignoringOtherApps: true)
+        if #available(macOS 14.0, *) {
+            NSApp.activate()
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+        }
     }
 }

--- a/apps/cmd-ime-swift/scripts/generate-self-signed-cert.sh
+++ b/apps/cmd-ime-swift/scripts/generate-self-signed-cert.sh
@@ -8,27 +8,24 @@ set -euo pipefail
 IDENTITY_NAME="CmdIME Self-Signed Publisher"
 OUT_P12="cmdime-signing.p12"
 PASSWORD=$(openssl rand -base64 12)
+KEYCHAIN="tmp.keychain"
 
 echo ">> Generating self-signed certificate for: $IDENTITY_NAME"
 
-# Create a temporary keychain
-KEYCHAIN="tmp.keychain"
+# Ensure cleanup on exit (success or failure)
+trap 'security delete-keychain "$KEYCHAIN" 2>/dev/null; rm -f key.pem cert.pem' EXIT
+
+# Create a temporary keychain (used by codesign when importing below)
 security create-keychain -p "" "$KEYCHAIN"
 
-# Generate the self-signed certificate in the temporary keychain
-# Using 'create-self-signed-certificate' (available in macOS)
-# Note: In modern macOS, 'security' command might not have a direct one-liner
-# for this that works headlessly easily. Let's use openssl and then import.
-
-openssl req -x509 -newkey rsa:2048 -keyout key.pem -out cert.pem -days 3650 -nodes \
+# Generate EC P-256 certificate (Apple recommends EC over RSA 2048 for code signing)
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 \
+    -keyout key.pem -out cert.pem -days 3650 -nodes \
     -subj "/CN=$IDENTITY_NAME"
 
 # Combine into P12
 openssl pkcs12 -export -out "$OUT_P12" -inkey key.pem -in cert.pem \
     -name "$IDENTITY_NAME" -passout "pass:$PASSWORD"
-
-# Cleanup
-rm key.pem cert.pem
 
 echo "----------------------------------------------------------"
 echo "Success! Generated: $OUT_P12"


### PR DESCRIPTION
## Summary

コード監査で発見された課題をまとめて修正。

### Swift app

- **#60** `BundleWatcher` を `AppDelegate` で起動 — `brew upgrade` 後の自動再起動が有効に
- **#61** `findMapping()` で `KeyMapping.enable` を評価 — 無効化されたマッピングが発火しなくなる
- **#70** `NSApp.activate(ignoringOtherApps:)` を `#available(macOS 14.0, *)` でガード
- **#71** deprecated `Process.launch()` を `try Process.run()` に置換
- **#72** `NSEvent` モニタートークンを保存し `[weak self]`・`deinit` でクリーンアップ
- **#73** `modifierMasks[keyCode]!` 強制アンラップを `guard let` に置換
- **#77** 未使用の `saveKeyMappings()` 関数を削除
- `convertedEvent()` 内の未使用 `KeyboardShortcut` 生成を削除

### CI/CD

- **#62** `CMDIME_SPARKLE_PRIVATE_ED_KEY` が未設定・空の場合に `exit 1` で明示的に失敗
- **#63** ZIP 作成を公証・stapling の後に移動（stapled チケットが Sparkle 配布物に含まれるように）
- **#64** `sparkle:version` の build number を git SHA → semver 由来の数値（例: `2.3.2` → `20302`）に変更
- **#65** `ci.yml` に SPM ビルドキャッシュを追加（PR ごとの Sparkle フルビルドを回避）
- **#66** `ci.yml` から `push: branches: [main]` トリガーを削除（PR マージ後の重複実行を排除）
- **#74** `release` ジョブに `timeout-minutes: 45` を追加
- **#75** Sparkle 秘密鍵ファイルを `trap` で確実にクリーンアップ
- **#76** `ci.yml` に `permissions: contents: read` を追加

### Scripts

- **#69** `generate-self-signed-cert.sh`: `trap` でキーチェーン削除を保証; RSA 2048 → EC P-256

## Test plan

- [x] `swift build` 成功
- [x] `swift test` 全20テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)