### PR TITLE
fix: address code audit findings (#60–#77)

### DIFF
--- a/.airis/generated.toml
+++ b/.airis/generated.toml
@@ -1,0 +1,3 @@
+# Auto-managed by airis gen — do not edit
+# Lists all files generated from manifest.toml
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,7 +98,7 @@ The tap can be disabled by macOS (e.g., on input-source change). `KeyEvent` hand
 ## Release Flow
 
 1. Update `manifest.toml` → `[project].version`
-2. Push to `main` → CI (`release.yml`) detects the new version tag does not exist
+2. Open a PR and merge to `main` → CI (`release.yml`) triggers on PR merge and detects the new version tag does not exist
 3. CI runs `scripts/package.sh` (builds, signs, bundles `CmdIME.app`)
 4. Creates DMG, optionally notarizes, creates GitHub Release
 5. Updates `agiletec-inc/homebrew-tap` Casks/cmd-ime.rb via squash-merged PR

--- a/README.md
+++ b/README.md
@@ -101,10 +101,9 @@ swift test
 |-----------|---------|
 | **[airis-mcp-gateway](https://github.com/agiletec-inc/airis-mcp-gateway)** | 🚪 Unified MCP hub with 90% token reduction |
 | **[mindbase](https://github.com/agiletec-inc/mindbase)** | 💾 Local cross-session memory with semantic search |
-| **[airis-agent](https://github.com/agiletec-inc/airis-agent)** | 🧠 Intelligence layer for AI coding |
 | **[airis-workspace](https://github.com/agiletec-inc/airis-workspace)** | 🏗️ Docker-first monorepo manager |
 | **[neural](https://github.com/agiletec-inc/neural)** | 🌐 Local LLM translation tool (DeepL alternative) |
-| **[airiscode](https://github.com/agiletec-inc/airiscode)** | 🖥️ Terminal-first autonomous coding agent |
+| **[airis-code](https://github.com/agiletec-inc/airis-code)** | 🖥️ Terminal-first autonomous coding agent |
 
 ---
 


### PR DESCRIPTION
## Summary

コード監査 (2026-05) で検出された指摘事項 #60–#77 への対応。

- コード監査の指摘 (#60–#77) を修正
- リリースを push トリガーではなく PR マージ時にトリガーするよう変更
- ドキュメント修正: リリースフロー説明、AIRIS リポジトリ参照名 (`airis-agent` 削除、`airiscode` → `airis-code`)
- `.airis/generated.toml` を `snapshots.toml` と同様に追跡対象に追加

## Test plan

- [ ] CI (release.yml は新バージョンタグ未存在時のみ発火するため本 PR では release は走らない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)