### PR TITLE
fix: AXObserver-driven smart switch + appcast branch (#67, #68)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,6 +254,16 @@ jobs:
           BUILD_NUMBER=$(echo "$VERSION" | awk -F. '{printf "%d%02d%02d", $1, $2, $3}')
           PUB_DATE=$(date -u "+%a, %d %b %Y %H:%M:%S +0000")
 
+          # Base the appcast off the accumulated copy on the `appcast` branch so
+          # every release entry is preserved. The first run (branch absent) falls
+          # back to the in-repo template, which carries an empty <channel>.
+          if git fetch origin appcast 2>/dev/null; then
+            git show FETCH_HEAD:appcast.xml > appcast.xml
+            echo "📥 Loaded accumulated appcast from the appcast branch"
+          else
+            echo "📄 appcast branch not found — seeding from the in-repo template"
+          fi
+
           awk \
             -v ver="$VERSION" \
             -v sig="$SIG" \
@@ -297,6 +307,37 @@ jobs:
             "appcast.xml"
 
           echo "✅ Release v${VERSION} created successfully!"
+
+      # Publish the accumulated appcast to a dedicated, unprotected `appcast`
+      # branch. SUFeedURL points at this branch's raw URL, so the feed no longer
+      # depends on the `latest` release staying in place, and every release's
+      # <item> is retained for version history and Sparkle delta generation.
+      # Runs after the release exists because the <enclosure> URL references the
+      # release download. The branch is a single force-pushed commit — its git
+      # history is irrelevant; the version history lives inside appcast.xml.
+      - name: Publish appcast.xml to appcast branch
+        if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION=${{ steps.version.outputs.version }}
+
+          WORKDIR=$(mktemp -d)
+          cp appcast.xml "$WORKDIR/appcast.xml"
+          cd "$WORKDIR"
+
+          git init -q
+          git checkout -q -b appcast
+          git add appcast.xml
+          git -c user.name="github-actions[bot]" \
+              -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+              commit -q -m "chore: publish appcast.xml for v${VERSION}"
+          git push -f \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            appcast
+
+          echo "✅ appcast.xml published to the appcast branch"
 
       # Mint a 1-hour GitHub App installation token instead of using a
       # static PAT. The `agiletec-inc-homebrew-publisher` App is installed

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ pnpm-lock.yaml
 pnpm-workspace.yaml
 node_modules/
 .airis/backups/
+
+# Claude Code harness artifacts
+.claude/scheduled_tasks.lock

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,9 @@ The tap can be disabled by macOS (e.g., on input-source change). `KeyEvent` hand
 2. Open a PR and merge to `main` → CI (`release.yml`) triggers on PR merge and detects the new version tag does not exist
 3. CI runs `scripts/package.sh` (builds, signs, bundles `CmdIME.app`)
 4. Creates DMG, optionally notarizes, creates GitHub Release
-5. Updates `agiletec-inc/homebrew-tap` Casks/cmd-ime.rb via squash-merged PR
+5. Appends the release entry to `appcast.xml` and force-pushes it to the dedicated `appcast` branch
+6. Updates `agiletec-inc/homebrew-tap` Casks/cmd-ime.rb via squash-merged PR
 
-The Sparkle auto-update feed is at `appcast.xml` on the `main` branch (referenced in `Info.plist` via `SUFeedURL`).
+The Sparkle auto-update feed lives on the dedicated `appcast` branch, served via its
+raw URL (`SUFeedURL` in `Info.plist`). Each release appends an `<item>`; the in-repo
+`appcast.xml` on `main` is only the empty seed template.

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/AutoSwitcher.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/AutoSwitcher.swift
@@ -5,6 +5,7 @@
 
 import Cocoa
 import Carbon.HIToolbox
+import Combine
 
 @MainActor
 final class AutoSwitcher {
@@ -18,19 +19,36 @@ final class AutoSwitcher {
     // When in an auto-switch field, this holds the source to restore on exit.
     private var savedBeforeAutoField: String?
 
-    private var pollTimer: Timer?
+    // AXObserver watching focus changes in the frontmost app (smart mode only).
+    // Replaces the old 500ms polling timer: the field is re-evaluated only when
+    // the focused UI element actually changes, not on a fixed schedule.
+    private var focusObserver: AXObserver?
+    private var observedPID: pid_t?
+    private var modeCancellable: AnyCancellable?
 
-    // Call once on app launch; timer runs forever but is a no-op when disabled.
+    // Call once on app launch.
     func start() {
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
-            MainActor.assumeIsolated { self?.tick() }
-        }
+        // React to switching-mode changes: attach the focus observer when smart
+        // mode is turned on, tear it down (and restore the input source) when it
+        // is turned off. @Published delivers the current value on subscription,
+        // so this also performs the initial wiring.
+        modeCancellable = AppSettings.shared.$switchingMode
+            .sink { [weak self] mode in
+                MainActor.assumeIsolated { self?.applySwitchingMode(mode) }
+            }
     }
 
     // Called by KeyEvent.setActiveApp on every app switch.
     func handleAppActivation(bundleID: String, pid: pid_t) {
         let mode = AppSettings.shared.switchingMode
         guard mode == .perApp || mode == .smart else { return }
+
+        // Re-point the focus observer at the newly activated app. Done before the
+        // same-app guard so an app relaunch (new pid, same bundle id) re-attaches.
+        if mode == .smart {
+            attachFocusObserver(pid: pid)
+        }
+
         guard bundleID != currentAppID else { return }
 
         if !currentAppID.isEmpty {
@@ -43,19 +61,73 @@ final class AutoSwitcher {
 
         currentAppID = bundleID
         savedBeforeAutoField = nil
-    }
 
-    // MARK: - Field polling (smart mode only)
-
-    private func tick() {
-        guard AppSettings.shared.switchingMode == .smart else {
-            if savedBeforeAutoField != nil { restoreFromAutoField() }
-            return
+        if mode == .smart {
+            checkSmartField()
         }
-        checkSmartField()
     }
+
+    private func applySwitchingMode(_ mode: AppSettings.SwitchingMode) {
+        if mode == .smart {
+            attachFocusObserverToFrontmostApp()
+            checkSmartField()
+        } else {
+            detachFocusObserver()
+            restoreFromAutoField()
+        }
+    }
+
+    // MARK: - Focus observer (smart mode only)
+
+    private func attachFocusObserverToFrontmostApp() {
+        guard let app = NSWorkspace.shared.frontmostApplication else { return }
+        attachFocusObserver(pid: app.processIdentifier)
+    }
+
+    private func attachFocusObserver(pid: pid_t) {
+        // Already watching this process — nothing to do.
+        guard observedPID != pid else { return }
+        detachFocusObserver()
+
+        var observer: AXObserver?
+        // The C callback cannot capture context; it is handed `self` via refcon.
+        let created = AXObserverCreate(pid, { _, _, _, refcon in
+            guard let refcon else { return }
+            let switcher = Unmanaged<AutoSwitcher>.fromOpaque(refcon).takeUnretainedValue()
+            MainActor.assumeIsolated { switcher.checkSmartField() }
+        }, &observer)
+
+        guard created == .success, let observer else { return }
+
+        let appElement = AXUIElementCreateApplication(pid)
+        let refcon = Unmanaged.passUnretained(self).toOpaque()
+        for notification in [
+            kAXFocusedUIElementChangedNotification,
+            kAXFocusedWindowChangedNotification
+        ] as [String] {
+            AXObserverAddNotification(observer, appElement, notification as CFString, refcon)
+        }
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(observer), .defaultMode)
+
+        focusObserver = observer
+        observedPID = pid
+    }
+
+    private func detachFocusObserver() {
+        guard let observer = focusObserver else { return }
+        CFRunLoopRemoveSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(observer), .defaultMode)
+        focusObserver = nil
+        observedPID = nil
+    }
+
+    // MARK: - ASCII-only field detection
 
     private func checkSmartField() {
+        guard AppSettings.shared.switchingMode == .smart else {
+            restoreFromAutoField()
+            return
+        }
+
         guard let app = NSWorkspace.shared.frontmostApplication,
               let bundleID = app.bundleIdentifier,
               exclusionAppsDict[bundleID] == nil else {
@@ -88,8 +160,6 @@ final class AutoSwitcher {
         selectInputSource(id: saved)
         savedBeforeAutoField = nil
     }
-
-    // MARK: - ASCII-only field detection
 
     private func isASCIIOnlyField(_ element: AXUIElement) -> Bool {
         var roleRef: AnyObject?
@@ -149,7 +219,7 @@ final class AutoSwitcher {
     private func selectASCIICapable() {
         let conditions = [
             kTISPropertyInputSourceIsASCIICapable as String: true,
-            kTISPropertyInputSourceIsEnabled as String: true,
+            kTISPropertyInputSourceIsEnabled as String: true
         ] as CFDictionary
         guard let cfList = TISCreateInputSourceList(conditions, false)?.takeRetainedValue() else { return }
         let list = cfList as NSArray

--- a/apps/cmd-ime-swift/scripts/package.sh
+++ b/apps/cmd-ime-swift/scripts/package.sh
@@ -198,7 +198,7 @@ cat > "$INFO_PLIST" <<EOF
     <key>NSHighResolutionCapable</key>
     <true/>
     <key>SUFeedURL</key>
-    <string>https://github.com/agiletec-inc/cmd-ime/releases/latest/download/appcast.xml</string>
+    <string>https://raw.githubusercontent.com/agiletec-inc/cmd-ime/appcast/appcast.xml</string>
     <key>SUPublicEDKey</key>
     <string>$SPARKLE_PUBLIC_ED_KEY</string>
 EOF


### PR DESCRIPTION
Closes #67
Closes #68

コード監査の残課題2件 (#67, #68) を修正。

## #67 — AutoSwitcher の AX ポーリング廃止

Smart モードの `tick()` が 500ms ごとにメインスレッドで最大8回の同期 AX IPC コールを発行していた（最大16 IPC/秒の常時実行）。

**変更:** ポーリングタイマーを廃止し、`AXObserver` ベースに置き換え。

- 前面アプリの `kAXFocusedUIElementChangedNotification` / `kAXFocusedWindowChangedNotification` を監視し、**フォーカスが実際に動いたときだけ**フィールド評価を実行
- アプリ切り替え時 (`handleAppActivation`) に observer を新しいプロセスへ付け替え
- `switchingMode` の変更を購読し、smart モードの ON/OFF で observer を attach/detach
- 恒常的な CPU wake-up とメインスレッドブロックを解消

## #68 — appcast.xml を専用ブランチに蓄積

リポジトリの `appcast.xml` は常に空で、`SUFeedURL` が `releases/latest/download/appcast.xml` を指していたため、リリース履歴が蓄積されず、`latest` リリースの削除・移動で全ユーザーの更新チェックが壊れる単一障害点だった。

**変更:**

- `release.yml`: リリース作成後に `appcast.xml` を専用の（保護されていない）`appcast` ブランチへ force-push。次回リリースはこのブランチの内容をベースに `<item>` を追記するため履歴が蓄積される
- `SUFeedURL` を `appcast` ブランチの raw URL に変更 → `latest` リリースへの依存を解消
- 既存の release アセットとしての `appcast.xml` アップロードは後方互換のため維持

## 変更ファイル

| ファイル | 内容 |
|---------|------|
| `apps/cmd-ime-swift/Sources/CmdIMESwift/AutoSwitcher.swift` | ポーリング→AXObserver |
| `.github/workflows/release.yml` | appcast 蓄積 + `appcast` ブランチへの publish ステップ追加 |
| `apps/cmd-ime-swift/scripts/package.sh` | `SUFeedURL` を `appcast` ブランチ raw URL に変更 |
| `CLAUDE.md` | Release Flow / appcast の記述を更新 |
| `.gitignore` | ハーネス生成物 `.claude/scheduled_tasks.lock` を除外 |

## Test plan

- [x] `swift build` 成功
- [x] `swift test` 全20件 pass
- [x] `swiftlint` 違反0 (AutoSwitcher.swift)
- [x] `release.yml` YAML 構文検証
- [ ] #67 のランタイム動作（Smart モードでのフィールド検出）は Accessibility 許可済み環境での手動確認が必要 — AX 連携は単体テスト不可
- [ ] #68 は実際のバージョン bump リリースでのみ動作確認可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)