### PR TITLE
ci(release): derive homebrew-publisher bot identity from token output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,8 +344,8 @@ jobs:
           echo "✅ appcast.xml published to the appcast branch"
 
       # Mint a 1-hour GitHub App installation token instead of using a
-      # static PAT. The `agiletec-inc-homebrew-publisher` App is installed
-      # on `homebrew-tap` only and shared via org-level credentials; same
+      # static PAT. The homebrew-publisher App is installed on
+      # `homebrew-tap` only and shared via org-level credentials; same
       # pattern as airis-workspace's release.yml. This eliminates the
       # per-repo HOMEBREW_TAP_TOKEN PAT (which expires and breaks silently).
       - name: Generate Homebrew tap App token
@@ -357,6 +357,28 @@ jobs:
           private-key: ${{ secrets.HOMEBREW_TAP_PUBLISHER_PRIVATE_KEY }}
           owner: agiletec-inc
           repositories: homebrew-tap
+          # Least-privilege scope: only what's needed to push the cask
+          # branch and open the PR. Survives any future App permission
+          # expansion without auto-inheriting the larger set.
+          permission-contents: write
+          permission-pull-requests: write
+
+      # Resolve the bot's numeric user-id so the committer email uses the
+      # canonical `<id>+<slug>[bot]@users.noreply.github.com` form GitHub
+      # recognizes as a verified author. Pulling `app-slug` from the token
+      # outputs means renaming the App needs no workflow edits.
+      - name: Resolve App bot identity
+        if: steps.check_tag.outputs.exists == 'false'
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          SLUG="${{ steps.app-token.outputs.app-slug }}"
+          USER_ID=$(gh api "/users/${SLUG}[bot]" --jq .id)
+          {
+            echo "name=${SLUG}[bot]"
+            echo "email=${USER_ID}+${SLUG}[bot]@users.noreply.github.com"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Update Homebrew cask via PR
         if: steps.check_tag.outputs.exists == 'false'
@@ -443,8 +465,8 @@ jobs:
           end
           EOF
 
-          git config user.name "agiletec-inc-homebrew-publisher[bot]"
-          git config user.email "agiletec-inc-homebrew-publisher[bot]@users.noreply.github.com"
+          git config user.name  "${{ steps.bot.outputs.name }}"
+          git config user.email "${{ steps.bot.outputs.email }}"
 
           git add Casks/cmd-ime.rb
           if git diff --cached --quiet; then


### PR DESCRIPTION
## Summary
- Resolve the publisher bot's committer name/email at runtime from \`steps.app-token.outputs.app-slug\` + the App's numeric user-id, instead of hardcoding \`agiletec-inc-homebrew-publisher[bot]\` in \`git config\` calls.
- Add least-privilege scopes (\`permission-contents: write\` + \`permission-pull-requests: write\`) on the minted installation token.

## Why
The App was renamed \`agiletec-inc-homebrew-publisher\` → \`agiletec-homebrew-publisher\`. The hardcoded committer in this workflow was already pointing at an account that no longer exists; the next release would have silently produced unverified commits in the cask PR.

The committer email was also missing the \`<user-id>+\` numeric prefix the [actions/create-github-app-token README](https://github.com/actions/create-github-app-token/blob/main/README.md#configure-git-cli-for-an-apps-bot-user) prescribes for verified bot authorship.

Mirror PR on airis-workspace: [#270](https://github.com/agiletec-inc/airis-workspace/pull/270).

## Test plan
- [ ] Next release opens a cask PR against \`agiletec-inc/homebrew-tap\`
- [ ] Commit author shows the green-check verified arrow
- [ ] PR auto-merges via the App's \`bypass_mode: pull_request\` actor entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)