### PR TITLE
release: ⌘IME 2.4.0 — gentle update reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ on the `main` branch via `.github/workflows/release.yml`.
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-06-06
+
+### Added
+- **Gentle update reminders** — as an `LSUIElement` menu bar agent, ⌘IME now
+  brings itself to the foreground while a Sparkle update is on screen and posts
+  a Notification Center banner for background/scheduled checks, so new versions
+  are noticed without a Dock icon to glance at (`SPUStandardUserDriverDelegate`,
+  per Sparkle's gentle-reminders guidance).
+
 ### Changed
 - Smart input switching re-evaluates the focused field via `AXObserver` instead
   of a 500 ms polling timer — lower idle CPU, immediate response (#67).

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/CmdIMEApp.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/CmdIMEApp.swift
@@ -1,9 +1,14 @@
 import Cocoa
 import Combine
 import Sparkle
+import UserNotifications
 
-class AppDelegate: NSObject, NSApplicationDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
+                   SPUStandardUserDriverDelegate, UNUserNotificationCenterDelegate {
     static weak var shared: AppDelegate?
+
+    // Identifier for the "update available" banner posted on background checks.
+    private static let updateNotificationIdentifier = "UpdateCheck"
 
     var statusItem: NSStatusItem!
     var windowController: NSWindowController?
@@ -22,20 +27,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let settings = AppSettings.shared
         settings.bootstrap()
 
-        updaterController = SPUStandardUpdaterController(startingUpdater: false, updaterDelegate: nil, userDriverDelegate: nil)
-        updaterController.updater.automaticallyChecksForUpdates = settings.checkUpdateAtLaunch
-        do {
-            try updaterController.updater.start()
-        } catch {
-            NSLog("⌘IME: Sparkle updater failed to start: %@", error.localizedDescription)
-        }
-
-        settings.$checkUpdateAtLaunch
-            .dropFirst()
-            .sink { [weak self] value in
-                self?.updaterController.updater.automaticallyChecksForUpdates = value
-            }
-            .store(in: &cancellables)
+        startSparkleUpdater(settings: settings)
 
         // Initialize preference window
         preferenceWindowController = PreferenceWindowController.getInstance()
@@ -79,6 +71,34 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    /// Configures and starts Sparkle, wiring the gentle-reminder delegates for this
+    /// menu bar agent and keeping automatic checks in sync with the user's preference.
+    private func startSparkleUpdater(settings: AppSettings) {
+        // userDriverDelegate enables Sparkle's "gentle reminders" for this LSUIElement
+        // menu bar agent: on a background/scheduled check we bring the app forward and
+        // post a Notification Center banner, instead of silently popping a dialog the
+        // user (who has no Dock icon to glance at) may never notice.
+        UNUserNotificationCenter.current().delegate = self
+        updaterController = SPUStandardUpdaterController(
+            startingUpdater: false,
+            updaterDelegate: self,
+            userDriverDelegate: self
+        )
+        updaterController.updater.automaticallyChecksForUpdates = settings.checkUpdateAtLaunch
+        do {
+            try updaterController.updater.start()
+        } catch {
+            NSLog("⌘IME: Sparkle updater failed to start: %@", error.localizedDescription)
+        }
+
+        settings.$checkUpdateAtLaunch
+            .dropFirst()
+            .sink { [weak self] value in
+                self?.updaterController.updater.automaticallyChecksForUpdates = value
+            }
+            .store(in: &cancellables)
+    }
+
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
         preferenceWindowController.showAndActivate(self)
         return false
@@ -99,6 +119,85 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     @IBAction func quit(_ sender: AnyObject) {
         NSApplication.shared.terminate(self)
+    }
+
+    // MARK: - Gentle update reminders (SPUStandardUserDriverDelegate)
+    //
+    // ⌘IME runs as an LSUIElement menu bar agent with no Dock icon, so Sparkle's
+    // standard update alert can surface behind other windows on an automatic check.
+    // Following Sparkle's "gentle reminders" guidance for background apps, we bring
+    // the app to the foreground while an update is on screen and post a Notification
+    // Center banner for non-user-initiated checks.
+    // https://sparkle-project.org/documentation/gentle-reminders
+
+    var supportsGentleScheduledUpdateReminders: Bool { true }
+
+    func standardUserDriverWillHandleShowingUpdate(
+        _ handleShowingUpdate: Bool,
+        forUpdate update: SUAppcastItem,
+        state: SPUUserUpdateState
+    ) {
+        // Bring the agent forward so the update dialog is frontmost and focusable.
+        NSApp.setActivationPolicy(.regular)
+
+        // Only nudge via a banner when the check was scheduled in the background; a
+        // user-initiated "Check for Updates…" already has the user's attention.
+        guard !state.userInitiated else { return }
+
+        NSApp.dockTile.badgeLabel = "1"
+        let content = UNMutableNotificationContent()
+        content.title = "⌘IME の新しいバージョンがあります"
+        content.body = "v\(update.displayVersionString) をインストールできます"
+        let request = UNNotificationRequest(
+            identifier: Self.updateNotificationIdentifier,
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request)
+    }
+
+    func standardUserDriverDidReceiveUserAttention(forUpdate update: SUAppcastItem) {
+        // The user engaged with the update, so clear the badge and any stale banner.
+        NSApp.dockTile.badgeLabel = ""
+        UNUserNotificationCenter.current()
+            .removeDeliveredNotifications(withIdentifiers: [Self.updateNotificationIdentifier])
+    }
+
+    func standardUserDriverWillFinishUpdateSession() {
+        // Return to menu-bar-only presence once the update interaction is over.
+        NSApp.setActivationPolicy(.accessory)
+    }
+
+    // MARK: - SPUUpdaterDelegate
+
+    func updater(_ updater: SPUUpdater, willScheduleUpdateCheckAfterDelay delay: TimeInterval) {
+        // Ask for notification permission only once automatic checks are actually
+        // scheduled (i.e. the user kept "check for updates on launch" enabled).
+        UNUserNotificationCenter.current()
+            .requestAuthorization(options: [.badge, .alert, .sound]) { _, _ in }
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler(.banner)
+    }
+
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        if response.notification.request.identifier == Self.updateNotificationIdentifier,
+           response.actionIdentifier == UNNotificationDefaultActionIdentifier {
+            // Clicking the banner opens Sparkle's update dialog.
+            updaterController.updater.checkForUpdates()
+        }
+        completionHandler()
     }
 }
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 [project]
 id = "cmd-ime"
 name = "⌘IME"
-version = "2.3.2"
+version = "2.4.0"
 description = "Lightweight macOS app for switching between alphanumeric and kana input using Command keys"
 authors = ["Kazuki <kazuki@agiletec.jp>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Cuts **2.4.0**, shipping the accumulated unreleased work plus a new gentle-reminders improvement to the in-app updater.

### New in this PR
- **Gentle update reminders** for the menu bar agent (`SPUStandardUserDriverDelegate`). As an `LSUIElement` app with no Dock icon, Sparkle's standard alert could surface behind other windows on a background/scheduled check. Now ⌘IME:
  - brings itself to the foreground while an update is on screen
  - posts a Notification Center banner for non-user-initiated checks
  - restores `.accessory` presence when the update session ends
  - requests notification permission only once automatic checks are scheduled

  Implemented per Sparkle's official [gentle-reminders](https://sparkle-project.org/documentation/gentle-reminders) guidance. The user-initiated "Check for Updates…" flow was already wired; this only improves how *background* checks surface.

### Also released (already on `main`, unreleased until now)
- AXObserver-driven smart input switching (#67), dedicated `appcast` branch feed (#68)
- Audit findings #60–#94, hardened-runtime Sparkle signing (#87), cask `auto_updates true` (#88)

## Verification
- `swift build -c release` ✅
- `swift test` ✅
- `swiftlint` — no new warnings in changed file ✅

On merge, `release.yml` builds/signs/notarizes, creates the GitHub Release + DMG, appends to the `appcast` branch, and opens the Homebrew tap bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)