### PR TITLE
release: ⌘IME 2.4.1 — Preferences ⌘W/⌘Q + release team-id guard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,8 @@ jobs:
 
       - name: Verify code signature
         if: steps.check_tag.outputs.exists == 'false'
+        env:
+          CMDIME_EXPECTED_TEAM_ID: ${{ vars.CMDIME_EXPECTED_TEAM_ID }}
         run: |
           set -euo pipefail
           codesign -dvv release/CmdIME.app 2>&1 | tee /tmp/codesign.log
@@ -147,6 +149,23 @@ jobs:
             echo "OK: signed with stable identity"
           else
             echo "::warning::bundle is ad-hoc signed; expected because CMDIME_SIGNING_CERT_P12_BASE64 is not set"
+          fi
+
+          # Guard against a signing-team change. Sparkle rejects an update whose code
+          # signature is from a different Apple team than the installed app, so a silent
+          # team switch breaks auto-updates for every existing user (see v2.3.2 -> v2.4.0
+          # where RYYXD43X4N -> X494AU8658 produced "An error occurred while running the
+          # updater"). Fail the release before publishing if the team drifts.
+          if [ -n "${CMDIME_EXPECTED_TEAM_ID:-}" ]; then
+            ACTUAL_TEAM=$(sed -n 's/.*TeamIdentifier=\([A-Z0-9]*\).*/\1/p' /tmp/codesign.log | head -1)
+            if [ "$ACTUAL_TEAM" != "$CMDIME_EXPECTED_TEAM_ID" ]; then
+              echo "ERROR: signing TeamIdentifier '$ACTUAL_TEAM' != expected '$CMDIME_EXPECTED_TEAM_ID'." >&2
+              echo "A team change breaks Sparkle auto-updates for existing users. Restore the prior" >&2
+              echo "CMDIME_SIGNING_IDENTITY/cert, or — if the change is deliberate — bump the" >&2
+              echo "CMDIME_EXPECTED_TEAM_ID repo variable (existing users will need a manual reinstall)." >&2
+              exit 1
+            fi
+            echo "OK: TeamIdentifier matches expected ($CMDIME_EXPECTED_TEAM_ID)"
           fi
 
       - name: Create DMG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ on the `main` branch via `.github/workflows/release.yml`.
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-06-06
+
+### Added
+- **Preferences window keyboard shortcuts** — a minimal main menu gives the window
+  ⌘W (close), ⌘M (minimize), and standard Cut/Copy/Paste/Select All in text fields.
+  ⌘Q closes the window and keeps ⌘IME in the menu bar by default; a new
+  **"Quit ⌘IME with ⌘Q"** toggle (General settings) opts into a full quit. The menu
+  bar "Quit" item always terminates.
+
+### Changed
+- The release workflow fails before publishing if the build's code-signing
+  `TeamIdentifier` drifts from `CMDIME_EXPECTED_TEAM_ID`, since a team change breaks
+  Sparkle auto-updates for already-installed users.
+
 ## [2.4.0] - 2026-06-06
 
 ### Added

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/CmdIMEApp.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/CmdIMEApp.swift
@@ -57,6 +57,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
         menu.addItem(withTitle: "Restart", action: #selector(AppDelegate.restart(_:)), keyEquivalent: "")
         menu.addItem(withTitle: "Quit", action: #selector(AppDelegate.quit(_:)), keyEquivalent: "q")
 
+        // A main menu lets the Preferences window honor ⌘W / ⌘Q and text-editing keys.
+        NSApp.mainMenu = makeMainMenu()
+
         MainActor.assumeIsolated { AutoSwitcher.shared.start() }
         keyEvent.start()
 
@@ -119,6 +122,72 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate,
 
     @IBAction func quit(_ sender: AnyObject) {
         NSApplication.shared.terminate(self)
+    }
+
+    // MARK: - Main menu & ⌘Q / ⌘W handling
+
+    /// Builds a minimal main menu so the Preferences window responds to the
+    /// standard shortcuts. As an LSUIElement agent ⌘IME has no menu bar of its
+    /// own; without this, ⌘W / ⌘Q and the text-editing keys do nothing while a
+    /// window is focused.
+    private func makeMainMenu() -> NSMenu {
+        let mainMenu = NSMenu()
+
+        // App menu — owns the ⌘Q equivalent. Whether it quits or merely closes the
+        // focused window is the user's choice (see handleCommandQ).
+        let appItem = NSMenuItem()
+        mainMenu.addItem(appItem)
+        let appMenu = NSMenu()
+        appItem.submenu = appMenu
+        let quitItem = appMenu.addItem(
+            withTitle: "Quit ⌘IME",
+            action: #selector(handleCommandQ(_:)),
+            keyEquivalent: "q"
+        )
+        quitItem.target = self
+
+        // Edit menu — routes Cut/Copy/Paste/Select All to the first responder so
+        // text fields (key recorder, app pickers) get the usual shortcuts.
+        let editItem = NSMenuItem()
+        mainMenu.addItem(editItem)
+        let editMenu = NSMenu(title: "Edit")
+        editItem.submenu = editMenu
+        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+
+        // Window menu — ⌘W closes the focused window (the agent stays in the menu
+        // bar); ⌘M minimizes it.
+        let windowItem = NSMenuItem()
+        mainMenu.addItem(windowItem)
+        let windowMenu = NSMenu(title: "Window")
+        windowItem.submenu = windowMenu
+        windowMenu.addItem(
+            withTitle: "Close",
+            action: #selector(NSWindow.performClose(_:)),
+            keyEquivalent: "w"
+        )
+        windowMenu.addItem(
+            withTitle: "Minimize",
+            action: #selector(NSWindow.performMiniaturize(_:)),
+            keyEquivalent: "m"
+        )
+        NSApp.windowsMenu = windowMenu
+
+        return mainMenu
+    }
+
+    /// ⌘Q handler. By default ⌘IME stays in the menu bar and ⌘Q only closes the
+    /// focused window; the user can opt into a full quit via Settings. The menu
+    /// bar "Quit" item always terminates regardless of this preference.
+    @objc func handleCommandQ(_ sender: Any?) {
+        let quitsApp = MainActor.assumeIsolated { AppSettings.shared.quitOnCommandQ }
+        if quitsApp {
+            NSApplication.shared.terminate(sender)
+        } else {
+            NSApp.keyWindow?.performClose(sender)
+        }
     }
 
     // MARK: - Gentle update reminders (SPUStandardUserDriverDelegate)

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/AppSettings.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/AppSettings.swift
@@ -29,6 +29,7 @@ final class AppSettings: ObservableObject {
         static let showMenuBarIcon = "showIcon"
         static let checkUpdateAtLaunch = "checkUpdateAtLaunch"
         static let legacyCheckUpdateAtLaunch = "checkUpdateAtlaunch"
+        static let quitOnCommandQ = "quitOnCommandQ"
         static let keyMappings = "mappings"
         static let exclusionApps = "exclusionApps"
         static let switchingMode = "switchingMode"
@@ -40,6 +41,7 @@ final class AppSettings: ObservableObject {
     @Published var launchAtStartup: Bool
     @Published var showMenuBarIcon: Bool
     @Published var checkUpdateAtLaunch: Bool
+    @Published var quitOnCommandQ: Bool
     @Published var keyMappings: [KeyMapping]
     @Published var exclusionApps: [AppData]
     @Published var switchingMode: SwitchingMode
@@ -54,6 +56,8 @@ final class AppSettings: ObservableObject {
 
         self.showMenuBarIcon = (defaults.object(forKey: Keys.showMenuBarIcon) as? Int ?? 1) != 0
         self.checkUpdateAtLaunch = (defaults.object(forKey: Keys.checkUpdateAtLaunch) as? Int ?? 1) != 0
+        // Default off: ⌘Q keeps the agent in the menu bar and only closes the window.
+        self.quitOnCommandQ = (defaults.object(forKey: Keys.quitOnCommandQ) as? Int ?? 0) != 0
 
         let stored = (defaults.object(forKey: Keys.launchAtStartup) as? Int ?? 0) != 0
         let serviceEnabled = SMAppService.mainApp.status == .enabled
@@ -140,12 +144,8 @@ final class AppSettings: ObservableObject {
             }
             .store(in: &cancellables)
 
-        $checkUpdateAtLaunch
-            .dropFirst()
-            .sink { [weak self] newValue in
-                self?.defaults.set(newValue ? 1 : 0, forKey: Keys.checkUpdateAtLaunch)
-            }
-            .store(in: &cancellables)
+        persistToggle($checkUpdateAtLaunch, to: Keys.checkUpdateAtLaunch)
+        persistToggle($quitOnCommandQ, to: Keys.quitOnCommandQ)
 
         $keyMappings
             .dropFirst()
@@ -170,6 +170,16 @@ final class AppSettings: ObservableObject {
             .dropFirst()
             .sink { [weak self] newValue in
                 self?.defaults.set(newValue.rawValue, forKey: Keys.switchingMode)
+            }
+            .store(in: &cancellables)
+    }
+
+    /// Persists a published Bool toggle to UserDefaults (stored as 0/1) on change.
+    private func persistToggle(_ publisher: Published<Bool>.Publisher, to key: String) {
+        publisher
+            .dropFirst()
+            .sink { [weak self] newValue in
+                self?.defaults.set(newValue ? 1 : 0, forKey: key)
             }
             .store(in: &cancellables)
     }

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/GeneralSettingsView.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/Settings/GeneralSettingsView.swift
@@ -17,6 +17,11 @@ struct GeneralSettingsView: View {
             Section {
                 Toggle("Launch at login", isOn: $settings.launchAtStartup)
                 Toggle("Show menu bar icon", isOn: $settings.showMenuBarIcon)
+                Toggle("Quit ⌘IME with ⌘Q", isOn: $settings.quitOnCommandQ)
+                Text("When off, ⌘Q just closes this window and ⌘IME keeps running "
+                     + "in the menu bar. You can quit anytime from the menu bar icon.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section {

--- a/apps/cmd-ime-swift/Tests/CmdIMESwiftTests/AppSettingsTests.swift
+++ b/apps/cmd-ime-swift/Tests/CmdIMESwiftTests/AppSettingsTests.swift
@@ -41,6 +41,31 @@ final class AppSettingsTests: XCTestCase {
         XCTAssertNil(defaults.object(forKey: "checkUpdateAtlaunch"))
     }
 
+    func testQuitOnCommandQDefaultsToOff() {
+        let settings = AppSettings(defaults: defaults)
+
+        // Default is off: ⌘Q keeps the agent in the menu bar (only closes the window).
+        XCTAssertFalse(settings.quitOnCommandQ)
+    }
+
+    func testQuitOnCommandQLoadsStoredValue() {
+        defaults.set(1, forKey: "quitOnCommandQ")
+
+        let settings = AppSettings(defaults: defaults)
+
+        XCTAssertTrue(settings.quitOnCommandQ)
+    }
+
+    func testQuitOnCommandQPersistsOnChange() {
+        let settings = AppSettings(defaults: defaults)
+
+        settings.quitOnCommandQ = true
+        XCTAssertEqual(defaults.object(forKey: "quitOnCommandQ") as? Int, 1)
+
+        settings.quitOnCommandQ = false
+        XCTAssertEqual(defaults.object(forKey: "quitOnCommandQ") as? Int, 0)
+    }
+
     func testLoadsDefaultKeyMappingsWhenNoneStored() {
         let settings = AppSettings(defaults: defaults)
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 [project]
 id = "cmd-ime"
 name = "⌘IME"
-version = "2.4.0"
+version = "2.4.1"
 description = "Lightweight macOS app for switching between alphanumeric and kana input using Command keys"
 authors = ["Kazuki <kazuki@agiletec.jp>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
2.4.1 fixes the Preferences window keyboard handling and hardens the release pipeline against the signing-team regression that broke v2.3.2 → v2.4.0 auto-updates.

### Preferences window shortcuts
⌘IME runs as an `LSUIElement` agent with no main menu, so the (normal) Preferences window ignored ⌘W/⌘Q and text-editing keys. Adds a minimal App/Edit/Window main menu:
- **⌘W** close window, **⌘M** minimize, **Cut/Copy/Paste/Select All** in text fields
- **⌘Q** closes the window and keeps ⌘IME in the menu bar **by default**; a new **"Quit ⌘IME with ⌘Q"** toggle (General settings) opts into a full quit. The menu bar **Quit** item always terminates.

### Release team-id guard
Switching the signing cert from `valuedata@gmail.com` (team `RYYXD43X4N`) to `kazuki.nakai@agiletec.net` (team `X494AU8658`) silently broke Sparkle auto-updates for installed 2.3.2 users — Sparkle rejects an update signed by a different team ("An error occurred while running the updater"). The release workflow now **fails before publishing** if the build's `TeamIdentifier` differs from the `CMDIME_EXPECTED_TEAM_ID` repo variable (`X494AU8658`).

## Tests
- `AppSettingsTests`: `quitOnCommandQ` default-off, load-stored, persist-on-change (9 AppSettings tests pass)
- `swift build -c release` ✅ · `swift test` ✅ · no new swiftlint warnings in changed files ✅

On merge → CI builds/signs (team guard enforced)/releases 2.4.1. This is the first release where existing **2.4.0** users can verify the in-app Sparkle update end-to-end (same team + EdDSA key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)