### PR TITLE
release: ⌘IME 2.4.2 — fix Sparkle update loop (numeric CFBundleVersion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ on the `main` branch via `.github/workflows/release.yml`.
 
 ## [Unreleased]
 
+## [2.4.2] - 2026-06-07
+
+### Fixed
+- **Sparkle re-offered the installed version on every launch.** `package.sh` stamped
+  `CFBundleVersion` with a git short hash while the appcast advertises a numeric
+  `<sparkle:version>` (`MAJOR*10000+MINOR*100+PATCH`), so the two never compared equal
+  and the updater looped — the downloaded build carried the same hash. `package.sh` now
+  derives `CFBundleVersion` with the same formula as `release.yml`, so an installed build
+  matches its appcast entry. (2.4.1 shipped without this fix.)
+
 ## [2.4.1] - 2026-06-06
 
 ### Added

--- a/apps/cmd-ime-swift/scripts/package.sh
+++ b/apps/cmd-ime-swift/scripts/package.sh
@@ -121,7 +121,10 @@ sign_bundle_with_runtime() {
 }
 
 VERSION="$(resolve_version)"
-BUILD_NUMBER=$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "1")
+# CFBundleVersion must match the appcast's <sparkle:version> (release.yml derives the same
+# MAJOR*10000+MINOR*100+PATCH build number). A git hash here never compares equal to the
+# numeric appcast value, so Sparkle re-offers the installed version on every launch.
+BUILD_NUMBER=$(echo "$VERSION" | awk -F. '{printf "%d%02d%02d", $1, $2, $3}')
 SIGN_IDENTITY="$(resolve_signing_identity)"
 SPARKLE_PUBLIC_ED_KEY="$(resolve_sparkle_public_key)"
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 [project]
 id = "cmd-ime"
 name = "⌘IME"
-version = "2.4.1"
+version = "2.4.2"
 description = "Lightweight macOS app for switching between alphanumeric and kana input using Command keys"
 authors = ["Kazuki <kazuki@agiletec.jp>"]
 license = "MIT"


### PR DESCRIPTION
## Summary
Patch release fixing the Sparkle "re-offers the update on every launch" loop.

`package.sh` stamped `CFBundleVersion` with a **git short hash**, while the appcast advertises a **numeric** `<sparkle:version>` (`MAJOR*10000+MINOR*100+PATCH`). The two never compared equal, so Sparkle kept thinking an update was available even right after installing it. `package.sh` now derives `CFBundleVersion` with the **same formula as `release.yml`** (verified locally: 2.4.2 → `20402`).

**2.4.1 shipped without this fix** (its `CFBundleVersion` is the git hash `55a5aec`) because the release was dispatched before the fix reached `main`. Sparkle serves the newest appcast entry, so existing users update straight to 2.4.2 and skip the buggy 2.4.1.

## Verification
- `package.sh` and `release.yml` now use an identical `BUILD_NUMBER` formula
- Local `package.sh` build produces `CFBundleVersion = 20402` (matches the appcast)
- Team guard from 2.4.1 still enforces `X494AU8658`

On merge, the release must be **manually dispatched** (auto-merge uses `GITHUB_TOKEN`, which doesn't trigger `release.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)