### PR TITLE
release: ⌘IME 2.4.3 — stable self-signed signing (persistent TCC + Sparkle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ on the `main` branch via `.github/workflows/release.yml`.
 
 ## [Unreleased]
 
+## [2.4.3] - 2026-06-07
+
+### Changed
+- **Code signing moved from an Apple Development certificate to a stable self-signed
+  identity ("CmdIME Self-Signed Publisher").** An Apple Development cert's Designated
+  Requirement pins the leaf certificate, which rotates ~yearly and resets macOS TCC
+  (Accessibility) grants; the self-signed identity is reused indefinitely, so
+  Accessibility grants and Sparkle updates now persist across releases without a paid
+  Apple Developer Program membership. The app is not notarized, so Gatekeeper shows a
+  one-time "unidentified developer" prompt on first launch (right-click → Open).
+  **Upgrading from ≤2.4.2 requires a one-time manual reinstall** (`brew upgrade --cask
+  cmd-ime`) and re-granting Accessibility, because changing the signing identity is a
+  one-time Designated-Requirement break that Sparkle's in-app updater rejects.
+
 ## [2.4.2] - 2026-06-07
 
 ### Fixed

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 [project]
 id = "cmd-ime"
 name = "⌘IME"
-version = "2.4.2"
+version = "2.4.3"
 description = "Lightweight macOS app for switching between alphanumeric and kana input using Command keys"
 authors = ["Kazuki <kazuki@agiletec.jp>"]
 license = "MIT"


### PR DESCRIPTION
## What

Switch release code-signing from a rotating **Apple Development** certificate to a reused **self-signed** identity (`CmdIME Self-Signed Publisher`).

## Why

An Apple Development cert's Designated Requirement pins the leaf certificate, which rotates ~yearly and resets macOS TCC (Accessibility) grants. A reused self-signed cert keeps the DR stable indefinitely → Accessibility grants **and** Sparkle updates persist across releases, with no paid Apple Developer Program.

## Config (already applied)

- secrets `CMDIME_SIGNING_CERT_P12_BASE64` / `CMDIME_SIGNING_CERT_PASSWORD` → self-signed p12
- var `CMDIME_SIGNING_IDENTITY` = `CmdIME Self-Signed Publisher`
- var `CMDIME_EXPECTED_TEAM_ID` removed (self-signed has no team)

## ⚠️ One-time migration

Upgrading from ≤2.4.2 needs a **one-time manual reinstall** (`brew upgrade --cask cmd-ime`) + re-grant Accessibility — the signing-identity change is a one-time Designated-Requirement break that Sparkle's in-app updater rejects. After that, TCC + Sparkle are stable.

Trade-off: not notarized → first-launch Gatekeeper "unidentified developer" prompt (right-click → Open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)