### PR TITLE
release: ⌘IME 2.4.4 — fix self-signed launch (drop hardened runtime)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ on the `main` branch via `.github/workflows/release.yml`.
 
 ## [Unreleased]
 
+## [2.4.4] - 2026-06-07
+
+### Fixed
+- **2.4.3 would not launch (self-signed + hardened runtime).** The hardened runtime
+  enforces library validation, which only loads a framework whose Team ID matches the
+  main process. A self-signed identity has no Team ID, so the main app could not load
+  the bundled (also Team-ID-less) `Sparkle.framework` — dyld killed it at launch with
+  "different Team IDs" and no Gatekeeper prompt. `package.sh` now applies the hardened
+  runtime only to Apple-issued certificates (which carry a Team ID and are what we'd
+  notarize); self-signed builds are signed without it.
+
 ## [2.4.3] - 2026-06-07
 
 ### Changed

--- a/apps/cmd-ime-swift/scripts/package.sh
+++ b/apps/cmd-ime-swift/scripts/package.sh
@@ -113,10 +113,18 @@ resolve_sparkle_public_key() {
 sign_bundle_with_runtime() {
     local path="$1"
     shift
+    # The hardened runtime enforces library validation, which only admits a loaded
+    # framework whose Team ID matches the main process's. A self-signed identity has no
+    # Team ID, so a hardened main app cannot load the bundled (also Team-ID-less)
+    # Sparkle.framework — dyld kills it at launch with "different Team IDs". Apply the
+    # hardened runtime only for Apple-issued certs (which carry a Team ID and are what
+    # we'd notarize); self-signed and local builds sign without it.
     if [[ "$BUILD_MODE" == "local" ]]; then
         codesign --force --sign "$SIGN_IDENTITY" "$@" "$path"
-    else
+    elif [[ "$SIGN_IDENTITY" == "Developer ID Application: "* || "$SIGN_IDENTITY" == "Apple Development: "* ]]; then
         codesign --force --timestamp --options runtime --sign "$SIGN_IDENTITY" "$@" "$path"
+    else
+        codesign --force --sign "$SIGN_IDENTITY" "$@" "$path"
     fi
 }
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 [project]
 id = "cmd-ime"
 name = "⌘IME"
-version = "2.4.3"
+version = "2.4.4"
 description = "Lightweight macOS app for switching between alphanumeric and kana input using Command keys"
 authors = ["Kazuki <kazuki@agiletec.jp>"]
 license = "MIT"


### PR DESCRIPTION
## What
2.4.3 (self-signed) won't launch — dyld kills it: the **hardened runtime's library validation** only loads frameworks whose Team ID matches the main process. A self-signed identity has **no Team ID**, so the main app can't load the bundled (also Team-ID-less) `Sparkle.framework` → `"different Team IDs"`, no Gatekeeper prompt.

## Fix
`package.sh` applies `--options runtime` (hardened runtime) **only to Apple-issued certs** (Developer ID / Apple Development — which carry a Team ID and are what we'd notarize). Self-signed builds sign without it. Verified locally: re-signing 2.4.3 without the hardened runtime → app launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)