### PR TITLE
chore(deps): bump Sparkle 2.9.1 → 2.9.3

### DIFF
--- a/apps/cmd-ime-swift/Package.resolved
+++ b/apps/cmd-ime-swift/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",
       "state" : {
-        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
-        "version" : "2.9.1"
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
       }
     }
   ],


### PR DESCRIPTION
## What

Bumps the pinned Sparkle version in `Package.resolved` from **2.9.1** to **2.9.3**.

## Why

Sparkle is the one dependency exposed to network-delivered update payloads, so it's worth keeping current:

- **2.9.2** shipped two security fixes (externally reported) for the auto-update framework.
- **2.9.3** is a further patch on top.

`Package.swift` already declares `from: "2.0.0"`, so only the committed `Package.resolved` was holding it back at 2.9.1.

## Diff

Single file — `apps/cmd-ime-swift/Package.resolved`:

```
-        "revision" : "066e75a8b3e99962685d6a90cdd5293ebffd9261",
-        "version" : "2.9.1"
+        "revision" : "d46d456107feacc80711b21847b82b07bd9fb46e",
+        "version" : "2.9.3"
```

## Verification

- `swift build` — clean
- `swift test` — **24 passing, 0 failures**
- `.build/artifacts/sparkle/Sparkle/bin/sign_update` (used by `release.yml` to sign the Sparkle enclosure) still resolves after the bump.

## Risk

Low. Patch-level bump within the same 2.9.x line; no API changes.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)