### PR TITLE
chore(release): 2.4.5 — Sparkle 2.9.3 + DMG staple ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ on the `main` branch via `.github/workflows/release.yml`.
 
 ## [Unreleased]
 
+## [2.4.5] - 2026-06-08
+
+### Security
+- **Bump Sparkle 2.9.1 → 2.9.3.** 2.9.2 shipped two externally reported security
+  fixes for the auto-update framework; 2.9.3 is a further patch. (#106)
+
+### Fixed
+- **Release: staple the app before building the DMG.** The DMG was previously built
+  from the un-stapled app, so the bundle inside the distributed DMG carried no
+  notarization ticket — a direct download would hit an online Gatekeeper check on
+  first launch. The release workflow now notarizes and staples the app first, then
+  builds the DMG from it. No effect until notarization is enabled. (#105)
+
 ## [2.4.4] - 2026-06-07
 
 ### Fixed

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 [project]
 id = "cmd-ime"
 name = "⌘IME"
-version = "2.4.4"
+version = "2.4.5"
 description = "Lightweight macOS app for switching between alphanumeric and kana input using Command keys"
 authors = ["Kazuki <kazuki@agiletec.jp>"]
 license = "MIT"


### PR DESCRIPTION
Cuts **v2.4.5** to ship the two audit fixes already merged to `main`:

- **#106 / #108** — Sparkle 2.9.1 → 2.9.3 (security fixes from 2.9.2).
- **#105 / #109** — release.yml staples the app before building the DMG (no user-facing effect until notarization is enabled, but lands the workflow correctness).

## What this PR changes

- `manifest.toml`: `2.4.4` → `2.4.5` (the version SSoT that `release.yml` reads).
- `CHANGELOG.md`: 2.4.5 entry.

## On merge

`release.yml` fires, sees `v2.4.5` does not yet exist, and runs the full release:
build → sign (self-signed; notarization still gated on `APPLE_ID`) → DMG/ZIP → Sparkle EdDSA sign → append to `appcast` branch → GitHub Release → homebrew-tap cask PR (auto-squash-merged).

I'll verify the appcast branch and homebrew-tap cask after the release job completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)