### PR TITLE
fix(keyevent): recover event tap after external monitor connect/disconnect (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ on the `main` branch via `.github/workflows/release.yml`.
 
 ## [Unreleased]
 
+## [2.4.6] - 2026-06-10
+
+### Fixed
+- **Recover the keyboard listener after an external monitor connect/disconnect.**
+  A display reconfiguration could leave the system event tap disabled (or in a
+  half-dead state where `tapIsEnabled()` still reported `true`), making ⌘IME stop
+  switching input sources until a restart. The callback now re-enables the tap the
+  instant macOS delivers a `tapDisabledByTimeout`/`tapDisabledByUserInput` event,
+  and a `CGDisplayReconfiguration` callback proactively rebuilds the tap on any
+  display add/remove/mode change. (#107)
+
 ## [2.4.5] - 2026-06-08
 
 ### Security

--- a/apps/cmd-ime-swift/Sources/CmdIMESwift/KeyEvent.swift
+++ b/apps/cmd-ime-swift/Sources/CmdIMESwift/KeyEvent.swift
@@ -38,6 +38,10 @@ class KeyEvent: NSObject {
         tapObserver?.release()
         nsEventMonitors.forEach { NSEvent.removeMonitor($0) }
         NSWorkspace.shared.notificationCenter.removeObserver(self)
+        CGDisplayRemoveReconfigurationCallback(
+            displayReconfigurationCallback,
+            UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        )
     }
 
     func start() {
@@ -119,6 +123,30 @@ class KeyEvent: NSObject {
 
         // CGEvent tap can run on main thread's RunLoop since NSApplication.run() handles it
         setupCGEventTap()
+
+        // Watch for display add/remove/mode changes. A monitor connect/disconnect
+        // can leave the session tap half-dead (tapIsEnabled() still reports true,
+        // so the heartbeat never recreates it). Force a rebuild on reconfiguration.
+        CGDisplayRegisterReconfigurationCallback(
+            displayReconfigurationCallback,
+            UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        )
+    }
+
+    func handleDisplayReconfiguration(flags: CGDisplayChangeSummaryFlags) {
+        // Reconfiguration fires twice (begin + end); act only on the end pass.
+        if flags.contains(.beginConfigurationFlag) { return }
+        guard shouldRebuildTap(for: flags) else { return }
+
+        NSLog("⌘IME: display reconfiguration detected; rebuilding CGEvent tap.")
+        setupCGEventTap()
+    }
+
+    func shouldRebuildTap(for flags: CGDisplayChangeSummaryFlags) -> Bool {
+        let relevant: CGDisplayChangeSummaryFlags = [
+            .addFlag, .removeFlag, .enabledFlag, .disabledFlag, .setModeFlag
+        ]
+        return !flags.isDisjoint(with: relevant)
     }
 
     func setupCGEventTap() {
@@ -223,6 +251,18 @@ class KeyEvent: NSObject {
     }
 
     func eventCallback(proxy: CGEventTapProxy, type: CGEventType, event: CGEvent) -> Unmanaged<CGEvent>? {
+        // The system delivers the tap-disabled types to this callback when it
+        // disables the tap (timeout under load, or display reconfiguration on
+        // monitor connect/disconnect — #107). Re-enable immediately instead of
+        // waiting for the 5-second heartbeat.
+        if type.isTapDisabled {
+            NSLog("⌘IME: CGEvent tap disabled by system (type %u); re-enabling.", type.rawValue)
+            if let tap = eventTap {
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return Unmanaged.passRetained(event)
+        }
+
         if isExclusionApp || isRecordingShortcut {
             return Unmanaged.passRetained(event)
         }
@@ -368,6 +408,25 @@ class KeyEvent: NSObject {
         )
         return .remap(ev)
     }
+}
+
+extension CGEventType {
+    /// Types the system delivers to a tap callback when it disables the tap.
+    var isTapDisabled: Bool {
+        self == .tapDisabledByTimeout || self == .tapDisabledByUserInput
+    }
+}
+
+/// File-level function so it converts to a stable C function pointer, letting
+/// `CGDisplayRemoveReconfigurationCallback` match the registration in `deinit`.
+private func displayReconfigurationCallback(
+    _ display: CGDirectDisplayID,
+    _ flags: CGDisplayChangeSummaryFlags,
+    _ userInfo: UnsafeMutableRawPointer?
+) {
+    guard let userInfo else { return }
+    let keyEvent = Unmanaged<KeyEvent>.fromOpaque(userInfo).takeUnretainedValue()
+    keyEvent.handleDisplayReconfiguration(flags: flags)
 }
 
 let modifierMasks: [CGKeyCode: CGEventFlags] = [

--- a/apps/cmd-ime-swift/Tests/CmdIMESwiftTests/KeyEventTests.swift
+++ b/apps/cmd-ime-swift/Tests/CmdIMESwiftTests/KeyEventTests.swift
@@ -76,4 +76,33 @@ final class KeyEventTests: XCTestCase {
         XCTAssertNotNil(result)
         XCTAssertEqual(result?.takeRetainedValue().getIntegerValueField(.keyboardEventKeycode), 0)
     }
+
+    // MARK: - Tap recovery (#107: external monitor connect/disconnect)
+
+    func testIsTapDisabled_TrueForSystemDisableTypes() {
+        XCTAssertTrue(CGEventType.tapDisabledByTimeout.isTapDisabled)
+        XCTAssertTrue(CGEventType.tapDisabledByUserInput.isTapDisabled)
+    }
+
+    func testIsTapDisabled_FalseForNormalEventTypes() {
+        XCTAssertFalse(CGEventType.keyDown.isTapDisabled)
+        XCTAssertFalse(CGEventType.keyUp.isTapDisabled)
+        XCTAssertFalse(CGEventType.flagsChanged.isTapDisabled)
+    }
+
+    func testShouldRebuildTap_TrueForDisplayAddRemoveAndModeChange() {
+        XCTAssertTrue(keyEvent.shouldRebuildTap(for: .addFlag))
+        XCTAssertTrue(keyEvent.shouldRebuildTap(for: .removeFlag))
+        XCTAssertTrue(keyEvent.shouldRebuildTap(for: .enabledFlag))
+        XCTAssertTrue(keyEvent.shouldRebuildTap(for: .disabledFlag))
+        XCTAssertTrue(keyEvent.shouldRebuildTap(for: .setModeFlag))
+        // Real reconfiguration end-pass flags often arrive combined.
+        XCTAssertTrue(keyEvent.shouldRebuildTap(for: [.addFlag, .setModeFlag]))
+    }
+
+    func testShouldRebuildTap_FalseForIrrelevantFlags() {
+        XCTAssertFalse(keyEvent.shouldRebuildTap(for: []))
+        XCTAssertFalse(keyEvent.shouldRebuildTap(for: .movedFlag))
+        XCTAssertFalse(keyEvent.shouldRebuildTap(for: .mirrorFlag))
+    }
 }

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,7 +3,7 @@
 [project]
 id = "cmd-ime"
 name = "⌘IME"
-version = "2.4.5"
+version = "2.4.6"
 description = "Lightweight macOS app for switching between alphanumeric and kana input using Command keys"
 authors = ["Kazuki <kazuki@agiletec.jp>"]
 license = "MIT"


### PR DESCRIPTION
Fixes #107.

## Problem
After connecting/disconnecting an external monitor, ⌘IME sometimes stops switching input sources until the app is restarted. A display reconfiguration disables the system `CGEvent` session tap — and in some cases leaves it *half-dead* (`tapIsEnabled()` still returns `true`), so the existing 5-second heartbeat never recreates it.

## Fix
1. **`eventCallback` handles the tap-disabled types.** macOS delivers `tapDisabledByTimeout` / `tapDisabledByUserInput` to the callback when it disables the tap. We now re-enable immediately instead of waiting for the heartbeat (previously these fell into the `default:` pass-through and were ignored).
2. **`CGDisplayRegisterReconfigurationCallback`.** On any display add/remove/enable/disable/mode-change we force a tap rebuild, covering the "tapIsEnabled lies" case.

## Tests
CI-safe unit tests for the pure decision helpers:
- `CGEventType.isTapDisabled` — true only for the two system disable types
- `shouldRebuildTap(for:)` — true for add/remove/enable/disable/setMode flags

The re-enable/rebuild side effects require Accessibility trust (unavailable in CI), so they are verified **manually** without external hardware:

> System Settings → Displays → toggle resolution/scaling (or `pmset displaysleepnow`, or Sidecar connect/disconnect). The same `CGDisplayReconfiguration` path fires. Watch Console for `⌘IME: display reconfiguration detected; rebuilding CGEvent tap.` and confirm ⌘ switching keeps working.

## Note for affected users
Existing installs that are stuck should reinstall once: `brew reinstall --cask cmd-ime` (or download the latest DMG). See the issue thread for the full clean-reinstall steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)