### PR TITLE
ci: adopt org Swift baseline reusable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,41 +1,21 @@
 name: CI
 
+# Org reusable CI caller — opinionated Swift baseline (swift test + release smoke).
+# Package.swift lives in apps/cmd-ime-swift; release smoke is the repo's package.sh.
+# Logic lives in agiletec-inc/.github. Required checks: "secret-scan / scan", "ci / ci".
 on:
   pull_request:
-    branches: [main]
-    paths-ignore:
-      - '**/*.md'
-      - 'appcast.xml'
-      - '.github/ISSUE_TEMPLATE/**'
-  workflow_dispatch:
+  merge_group:
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  secret-scan:
+    uses: agiletec-inc/.github/.github/workflows/secret-scan.yml@main
   ci:
-    runs-on: macos-latest
-    timeout-minutes: 20
-    permissions:
-      contents: read
-    defaults:
-      run:
-        working-directory: apps/cmd-ime-swift
-    steps:
-      - uses: actions/checkout@v6
-      - name: Cache Swift build
-        uses: actions/cache@v4
-        with:
-          path: apps/cmd-ime-swift/.build
-          key: ${{ runner.os }}-spm-${{ hashFiles('apps/cmd-ime-swift/Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-spm-
-      - name: Test
-        run: swift test
-      # Exercise the release path on every PR so a release-config-only break
-      # or a package.sh regression is caught before merge, not after.
-      - name: Release build smoke test
-        env:
-          CMDIME_BUILD_MODE: local
-        run: bash scripts/package.sh
+    uses: agiletec-inc/.github/.github/workflows/swift-ci.yml@main
+    with:
+      working-directory: apps/cmd-ime-swift
+      release-command: CMDIME_BUILD_MODE=local bash scripts/package.sh


### PR DESCRIPTION
Replace bespoke ci.yml with the org `swift-ci` baseline (swift test + release smoke), passing `working-directory: apps/cmd-ime-swift` and `release-command: CMDIME_BUILD_MODE=local bash scripts/package.sh` to preserve the exact release-path smoke test. Required checks: `secret-scan / scan`, `ci / ci`. (Build cache dropped — perf only, no functional change.)