### PR TITLE
chore(funding): drop per-repo funding, inherit org SSoT

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# Funding goal: $99/year Apple Developer Program → notarized builds (no Gatekeeper warning).
-github: [kazukinakai]
-buy_me_a_coffee: kazukinakad

--- a/README.md
+++ b/README.md
@@ -107,19 +107,6 @@ swift test
 
 ---
 
-## 💖 Support This Project
-
-⌘IME is free and open source (MIT) — you never have to pay for it. Use it quietly, or, if it saved your fingers some gymnastics, a tweet or a ⭐ goes a long way. 🙂
-
-Right now it ships via Homebrew and a direct DMG. The app is **self-signed, not yet Apple-notarized** — the source is fully open so you can verify it, but a direct DMG download still trips Gatekeeper's "unidentified developer" warning (Homebrew users don't hit this). Clearing that needs an **Apple Developer Program membership — $99/year** for a Developer ID and notarization, so every install is one click. I'm saving toward it; the same membership would also cover my other open-source Swift apps.
-
-So if ⌘IME — or any of the [AIRIS tools](#-part-of-the-airis-ecosystem) — earned a spot in your workflow and you feel like chipping in toward that $99, a coffee or a sponsorship is hugely appreciated. Entirely optional, no pressure.
-
-[![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-support-yellow?style=for-the-badge&logo=buy-me-a-coffee)](https://buymeacoffee.com/kazukinakad)
-[![GitHub Sponsors](https://img.shields.io/badge/GitHub%20Sponsors-sponsor-pink?style=for-the-badge&logo=github)](https://github.com/sponsors/kazukinakai)
-
----
-
 ## 🤝 Contributing
 
 We welcome contributions! Please:


### PR DESCRIPTION
Removes cmd-ime's per-repo funding so it inherits the single org Source of Truth (`agiletec-inc/.github/FUNDING.yml`).

## Why
PR #104 added a per-repo `.github/FUNDING.yml` (`github: kazukinakai`, `buy_me_a_coffee: kazukinakad`) plus a README "Support" section pointing at **personal** accounts. That overrode the org-level Sponsor target and mixed personal/org funding contexts. Per the org-wide funding cleanup, org repos use **org** funding only; personal accounts stay in their own context.

## Changes
- Delete `.github/FUNDING.yml` → falls back to the org default community health file (`agiletec-inc/.github`), so the Sponsor button resolves to `agiletec-inc`.
- Remove the README `💖 Support This Project` section (personal links + `$99` narrative). The notarization-funding story moves to the org Sponsors listing, not per-repo text.

No code/release impact (the #107 fix and v2.4.6 are unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)