### PR TITLE
docs(readme): add org GitHub Sponsors support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ MIT License - See [LICENSE](LICENSE) file for details.
 
 Based on the original [cmd-eikana](https://github.com/imasanari/cmd-eikana) project.
 
+## 💖 Support
+
+[agiletec](https://github.com/agiletec-inc) is a one-person studio building these tools full-time and open source. If they earn a spot in your workflow, a sponsorship keeps them maintained and independent.
+
+[![Sponsor agiletec](https://img.shields.io/badge/Sponsor-agiletec-ea4aaa?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/agiletec-inc)
+
 ---
 
 **Built with ❤️ by the [Agiletec](https://github.com/agiletec-inc) team**


### PR DESCRIPTION
Adds a consistent **GitHub Sponsors** funding section (org `agiletec-inc`) to the README so the funding ask is visible in the body, not just the subtle Sponsor button. Same canonical snippet across all public product repos; personal/dead links stay out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)